### PR TITLE
Rework type for variadics

### DIFF
--- a/tests/arguments.test-d.ts
+++ b/tests/arguments.test-d.ts
@@ -4,9 +4,6 @@ import { Command, Argument, OptionValues } from '..';
 // Reusing same program variable through tests for convenience.
 const program = new Command();
 
-// Non-empty array, but may dumb it down to string[] as minor benefits.
-type VaridicStrings = [string, ...string[]];
-
 /**
  * Check when no command-arguments.
  */
@@ -53,21 +50,22 @@ program
 program
   .argument('<mult...>')
   .action((m, options) => {
-    expectType<VaridicStrings>(m);
+    expectType<string[]>(m);
     expectAssignable<OptionValues>(options);
   });
 
 program
   .argument('[mult...]')
   .action((m, options) => {
-    expectType<VaridicStrings | undefined>(m);
+    expectType<string[]>(m);
     expectAssignable<OptionValues>(options);
   });
 
 program
-  .argument('[mult...]', 'description', ['a'])
+  .argument('[mult...]', 'description', [])
   .action((m, options) => {
-    expectType<VaridicStrings | string[]>(m);
+    // The wild looking never[] is how TypeScript represents the type of the untyped empty array passed as default.
+    expectType<string[] | never[]>(m);
     expectAssignable<OptionValues>(options);
   });
 
@@ -131,7 +129,7 @@ program
   .action((foo1, foo2, mult, options) => {
     expectType<string>(foo1);
     expectType<string>(foo2);
-    expectType<VaridicStrings | undefined>(mult);
+    expectType<string[]>(mult);
     expectAssignable<OptionValues>(options);
   });
 
@@ -165,7 +163,7 @@ program
 program
   .addArgument(new Argument('<foo...>'))
   .action((foo, options) => {
-    expectType<VaridicStrings>(foo);
+    expectType<string[]>(foo);
     expectAssignable<OptionValues>(options);
   });
 

--- a/tests/options.test-d.ts
+++ b/tests/options.test-d.ts
@@ -1,9 +1,6 @@
 import { expectType, expectAssignable } from 'tsd';
 import { Command, Option, OptionValues } from '..';
 
-// Non-empty array, but may dumb it down to string[] as minor benefits.
-type VaridicStrings = [string, ...string[]];
-
 function myParseInt(arg: string, previous: number): number {
   return parseInt(arg);
 }
@@ -32,12 +29,12 @@ expectType<{ o?: string | true }>(o3);
 const o4 = program
   .option('--debug <value...>')
   .opts();
-expectType<{ debug?: [string, ...string[]] }>(o4);
+expectType<{ debug?: string[] }>(o4);
 
 const o5 = program
   .option('--debug [value...]')
   .opts();
-expectType<{ debug?: [string, ...string[]] | true }>(o5);
+expectType<{ debug?: string[] | true }>(o5);
 if (o5.debug !== true && o5.debug !== undefined) o5.debug[0] = 'a'; // check expecting non-empty
 
 // with default
@@ -60,12 +57,12 @@ expectType<{ debug: string | true }>(o8);
 const o9 = program
   .option('--debug <value...>', 'description', [])
   .opts();
-expectType<{ debug: VaridicStrings | [] }>(o9);
+expectType<{ debug: [] | string[] }>(o9);
 
 const o10 = program
   .option('--debug [value...]', 'description', [])
   .opts();
-expectType<{ debug: VaridicStrings | true | [] }>(o10);
+expectType<{ debug: string[] | true | [] }>(o10);
 
 // Coerce/custom, w/wo defaults
 


### PR DESCRIPTION
1) a variadic optional argument like `.argument('[file...])` returns an empty array when no value is specified on command-line. Representing this is the main goal of PR.

2) was attempting to represent non-empty arrays with tuple like `[string, ...string[]]`, but decided it didn't add much, and was unfamiliar looking, and has potential downsides. Too tricky! Instead, just use ordinary array.

https://stackoverflow.com/questions/56006111/is-it-possible-to-define-a-non-empty-array-type-in-typescript

3) a side-note that empty arrays are a special beast! Can be assigned to typed array, but are untyped. I found one case where resulting argument type included a `never[]` and eventually decided it was intended by TypeScript!

https://www.explainprogramming.com/typescript/never-type/#what-is-never-when-using-strictnullchecks