### PR TITLE
Allow author defined option source

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,14 @@ type CamelCase<S extends string> = S extends `${infer W}-${infer Rest}`
 // - https://effectivetypescript.com/2022/02/25/gentips-4-display/
 type Resolve<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 
+// This is a trick to encourage editor to suggest the known literals while still
+// allowing any BaseType value.
+// References:
+// - https://github.com/microsoft/TypeScript/issues/29729
+// - https://github.com/sindresorhus/type-fest/blob/main/source/literal-union.d.ts
+// - https://github.com/sindresorhus/type-fest/blob/main/source/primitive.d.ts
+type LiteralUnion<LiteralType, BaseType extends string | number> = LiteralType | (BaseType & Record<never, never>);
+
 // Side note: not trying to represent arrays as non-empty, keep it simple.
 // https://stackoverflow.com/a/56006703/1082434
 type InferVariadic<S extends string, ArgT> =
@@ -72,7 +80,7 @@ type ConvertFlagToName<Flag extends string> =
             ? CamelCase<Name>
             : never;
 
-type CombineOptions<Options extends Record<string, any>, B extends Record<string, any>> =
+type CombineOptions<Options extends OptionValues, B extends OptionValues> =
     keyof B extends keyof Options
         ? { [K in keyof Options]: K extends keyof B ? Options[K] | B[keyof B] : Options[K] }
         : Resolve<Options & B>;
@@ -415,8 +423,9 @@ export class CommanderError extends Error {
   
   export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
   export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
-  export type OptionValueSource = 'default' | 'env' | 'config' | 'cli';
-  
+  // The source is a string so author can define their own too.
+  export type OptionValueSource = LiteralUnion<'default' | 'implied' | 'config' | 'env' | 'cli', string>;
+
   export interface OptionValues {
     [key: string]: any;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -424,7 +424,7 @@ export class CommanderError extends Error {
   export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
   export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
   // The source is a string so author can define their own too.
-  export type OptionValueSource = LiteralUnion<'default' | 'implied' | 'config' | 'env' | 'cli', string> | undefined;
+  export type OptionValueSource = LiteralUnion<'default' | 'config' | 'env' | 'cli' | 'implied', string> | undefined;
 
   export interface OptionValues {
     [key: string]: any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,10 +80,10 @@ type ConvertFlagToName<Flag extends string> =
             ? CamelCase<Name>
             : never;
 
-type CombineOptions<Options extends OptionValues, B extends OptionValues> =
-    keyof B extends keyof Options
-        ? { [K in keyof Options]: K extends keyof B ? Options[K] | B[keyof B] : Options[K] }
-        : Resolve<Options & B>;
+type CombineOptions<Options, O> =
+    keyof O extends keyof Options
+        ? { [K in keyof Options]: K extends keyof O ? Options[K] | O[keyof O] : Options[K] }
+        : Options & O;
 
 type IsAlwaysDefined<DefaulT, Mandatory extends boolean> =
     Mandatory extends true
@@ -430,7 +430,7 @@ export class CommanderError extends Error {
     [key: string]: any;
   }
   
-  export class Command<Args extends any[] = [], Opts = {}> {
+  export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
     args: string[];
     processedArgs: any[];
     commands: Command[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -424,7 +424,7 @@ export class CommanderError extends Error {
   export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
   export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
   // The source is a string so author can define their own too.
-  export type OptionValueSource = LiteralUnion<'default' | 'implied' | 'config' | 'env' | 'cli', string>;
+  export type OptionValueSource = LiteralUnion<'default' | 'implied' | 'config' | 'env' | 'cli', string> | undefined;
 
   export interface OptionValues {
     [key: string]: any;

--- a/tests/literal-unions-d.ts
+++ b/tests/literal-unions-d.ts
@@ -1,0 +1,12 @@
+import { expectType, expectAssignable } from 'tsd';
+import { Command, Option, OptionValues } from '..';
+
+const program = new Command();
+program.setOptionValueWithSource('key', 'value', 'cli'); // expected source used by Commander
+// Author is allowed to make up their own sources.
+program.setOptionValueWithSource('key', 'value', 'my-custom-source1');
+
+if (program.getOptionValueSource('key') === 'cli') {
+}
+if (program.getOptionValueSource('key') === 'my-custom-source2') {
+}


### PR DESCRIPTION
The intent is to allow the author to make up and use their own option sources for advanced cases. Since this is rare, we also want editor to suggest the values Commander knows about. At the time I wrote the code I was not comfortable doing the fancy typing to make this possible and went for just the known values to get the editor and TypeScript support.

This repo is adding extra typing, so seems a good place to try this out before adding into Commander.

Also adds `implied` which got left out when `Option.implies()` added: https://github.com/tj/commander.js/pull/1788#issuecomment-1233405495