### PR TITLE
Add return type for getOptionValue and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Fixed
 
-- a missing variadic command-line argument should be `[]` not `undefined`
+- a missing variadic optional command-line argument should be `[]` not `undefined`
 
 ## Changed
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -749,7 +749,7 @@ export class CommanderError extends Error {
     /**
      * Retrieve option value.
      */
-     getOptionValue<K extends string>(key: K): TypeFromKey<K, Opts>;
+    getOptionValue<K extends string>(key: K): TypeFromKey<K, Opts>;
   
     /**
      * Store option value.

--- a/index.d.ts
+++ b/index.d.ts
@@ -764,8 +764,8 @@ export class CommanderError extends Error {
     /**
      * Retrieve option value source.
      */
-     getOptionValueSource<K extends keyof Opts>(key: K): OptionValueSource;
-     getOptionValueSource(key: string): OptionValueSource;
+     getOptionValueSource<K extends keyof Opts>(key: K): OptionValueSource | undefined;
+     getOptionValueSource(key: string): OptionValueSource | undefined;
   
     /**
      * Alter parsing of short flags with optional values.

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,9 @@ type InferVariadic<S extends string, ArgT> =
     ? ArgT[]
     : ArgT;
 
+type TypeFromKey<K extends string, T> =
+    K extends keyof T ? T[K] : unknown;
+
 type InferArgumentType<Value extends string, DefaultT, CoerceT> =
   [CoerceT] extends [undefined]
     ? InferVariadic<Value, string> | DefaultT
@@ -746,7 +749,7 @@ export class CommanderError extends Error {
     /**
      * Retrieve option value.
      */
-    getOptionValue(key: string): any;
+     getOptionValue<K extends string>(key: K): TypeFromKey<K, Opts>;
   
     /**
      * Store option value.

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,9 +21,6 @@ type InferVariadic<S extends string, ArgT> =
     ? ArgT[]
     : ArgT;
 
-type TypeFromKey<K extends string, T> =
-    K extends keyof T ? T[K] : unknown;
-
 type InferArgumentType<Value extends string, DefaultT, CoerceT> =
   [CoerceT] extends [undefined]
     ? InferVariadic<Value, string> | DefaultT
@@ -749,7 +746,8 @@ export class CommanderError extends Error {
     /**
      * Retrieve option value.
      */
-    getOptionValue<K extends string>(key: K): TypeFromKey<K, Opts>;
+    getOptionValue<K extends keyof Opts>(key: K): Opts[K];
+    getOptionValue(key: string): unknown;
   
     /**
      * Store option value.

--- a/index.d.ts
+++ b/index.d.ts
@@ -752,17 +752,20 @@ export class CommanderError extends Error {
     /**
      * Store option value.
      */
-    setOptionValue(key: string, value: unknown): this;
+     setOptionValue<K extends keyof Opts>(key: K, value: unknown): this;
+     setOptionValue(key: string, value: unknown): this;
   
     /**
      * Store option value and where the value came from.
      */
-    setOptionValueWithSource(key: string, value: unknown, source: OptionValueSource): this;
+     setOptionValueWithSource<K extends keyof Opts>(key: K, value: unknown, source: OptionValueSource): this;
+     setOptionValueWithSource(key: string, value: unknown, source: OptionValueSource): this;
   
     /**
      * Retrieve option value source.
      */
-    getOptionValueSource(key: string): OptionValueSource;
+     getOptionValueSource<K extends keyof Opts>(key: K): OptionValueSource;
+     getOptionValueSource(key: string): OptionValueSource;
   
     /**
      * Alter parsing of short flags with optional values.

--- a/tests/option-value.test-d.ts
+++ b/tests/option-value.test-d.ts
@@ -1,0 +1,17 @@
+import { expectType } from 'tsd';
+import { Command } from '..';
+
+if ('getOptionValue is unknown when key is unknown') {
+  const program = new Command()
+    .option('-f, --foo');
+  
+  const v = program.getOptionValue('bar');
+  expectType<unknown>(v);
+}
+
+if ('getOptionValue result is typed when key is known') {
+  const program = new Command()
+    .option('-f, --foo');
+  const v = program.getOptionValue('foo');
+  expectType<true | undefined>(v);
+}

--- a/tests/option-value.test-d.ts
+++ b/tests/option-value.test-d.ts
@@ -1,7 +1,7 @@
 import { expectType } from 'tsd';
 import { Command } from '..';
 
-if ('getOptionValue is unknown when key is unknown') {
+if ('when getOptionValue is unknown then key is unknown') {
   const program = new Command()
     .option('-f, --foo');
   
@@ -9,7 +9,7 @@ if ('getOptionValue is unknown when key is unknown') {
   expectType<unknown>(v);
 }
 
-if ('getOptionValue result is typed when key is known') {
+if ('when getOptionValue result is typed then key is known') {
   const program = new Command()
     .option('-f, --foo');
   const v = program.getOptionValue('foo');


### PR DESCRIPTION
Return the type if the key to getOptionValue is known, or `unknown` if the key is not known.

The editor completion for the key shows the known keys from the strongly typed overload. Used the same approach for `getOptionSource` et al.

I wondered about a hard error for unknown keys, but thought the fallback overload might be a more usable approach. Unsafe use of the `unknown` returned value from `.getOptionValue()` will still cause errors.