### PR TITLE
Document issues with subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ This package offers experimental TypeScript typings for `commander` which infer 
 
 Limitations
 
-- subclassing is not directly supported for `Command`, `Argument`, or `Option`
 - the generics lead to some noisy types visible in editor and errors
+- some code changes for subclasses of `Command`, `Argument`, or `Option` (see [subclass.test-d.ts](./tests/subclass.test-d.ts))
+  - chaining methods which do type inference return base class rather than `this`
+  - subclass of `Command` returns base class not subclass from `.command(name)`
+  - type parameter needed for class declaration of subclass of `Option` and `Argument`
 
 Usage
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ type InferArguments<S extends string> =
         ? [InferArgument<First>, ...InferArguments<TrimLeft<Rest>>]
         : [InferArgument<S>];
 
-export type InferCommmandArguments<S extends string> =
+type InferCommmandArguments<S extends string> =
   S extends `${string} ${infer Args}`
       ? InferArguments<TrimLeft<Args>>
       : [];

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ type InferArguments<S extends string> =
         ? [InferArgument<First>, ...InferArguments<TrimLeft<Rest>>]
         : [InferArgument<S>];
 
-type InferCommmandArguments<S extends string> =
+export type InferCommmandArguments<S extends string> =
   S extends `${string} ${infer Args}`
       ? InferArguments<TrimLeft<Args>>
       : [];

--- a/tests/subclass.test-d.ts
+++ b/tests/subclass.test-d.ts
@@ -1,0 +1,58 @@
+import { expectType } from 'tsd';
+import { Command, Option, CommandOptions, InferCommmandArguments, ExecutableCommandOptions, OptionValues } from '..';
+
+// Breaking: need to add type parameter for use in super constructor
+class MyOption<Usage extends string = ''> extends Option<Usage> {
+    myFunction(): void {
+      // do nothing
+  }
+}
+
+class MyCommand extends Command {
+  createCommand(name?: string): MyCommand {
+    return new MyCommand(name);
+  }
+  createOption(flags: string, description?: string): MyOption {
+    return new MyOption(flags, description);
+  }
+
+  myFunction(): void {
+    // do nothing
+  }
+}
+
+if ('when add subcommand to MyCommand then return type is not MyCommand (limitation)') {
+  const myProgram = new MyCommand();
+  const mySub = myProgram.command('sub');
+  // Breaking: lost automatic custom typing of subcommands
+  // @ts-expect-error 
+  mySub.myFunction();
+}
+
+if ('when call chaining method using inference on MyCommand then return type not MyCommand (limitation)') {
+  new MyCommand().myFunction();
+  // Breaking: lost subclass when chain
+  // @ts-expect-error 
+  new MyCommand().opts('-f').myFunction();
+}
+
+if ('when add option to MyCommand then option type inferred') {
+  const program = new MyCommand()
+    .option('-f, --foo', 'foo description');
+  const foo = program.opts().foo;
+  expectType<true | undefined>(foo);
+}
+
+if ('when add MyOption to Command then option type inferred') {
+  const program = new Command()
+    .addOption(new MyOption('-f, --foo <value>', 'foo description').makeOptionMandatory());
+  const foo = program.opts().foo;
+  expectType<string>(foo);
+}
+
+if ('when call chaining method using inference on MyOption then return type not MyOption (limitation)') {
+  new MyOption('-f, --foo').myFunction();
+  // Breaking: lost subclass when chain
+  // @ts-expect-error 
+  new MyOption('-f, --foo').default(3).myFunction();
+}

--- a/tests/subclass.test-d.ts
+++ b/tests/subclass.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from 'tsd';
-import { Command, Option, CommandOptions, InferCommmandArguments, ExecutableCommandOptions, OptionValues } from '..';
+import { Command, Option } from '..';
 
 // Breaking: need to add type parameter for use in super constructor
 class MyOption<Usage extends string = ''> extends Option<Usage> {


### PR DESCRIPTION
I did some testing around subclasses to find out what code changes are required.

A subclass that doesn't change the API is fairly easy. But subclasses that add custom methods will be more painful as chaining methods drop the custom subclass type.