### PR TITLE
Add type inference for createOption

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -736,7 +736,7 @@ export class CommanderError extends Error {
      * create the option. You can override createOption to return a custom option.
      */
   
-    createOption(flags: string, description?: string): Option;
+    createOption<Usage extends string>(flags: Usage, description?: string): Option<Usage>;
   
     /**
      * Add a prepared Option.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1056,7 +1056,7 @@ export class CommanderError extends Error {
   }
   
   export function createCommand(name?: string): Command;
-  export function createOption(flags: string, description?: string): Option;
+  export function createOption<Usage extends string>(flags: Usage, description?: string): Option<Usage>;
   export function createArgument(name: string, description?: string): Argument;
   
   export const program: Command;

--- a/tests/create-option.test-d.ts
+++ b/tests/create-option.test-d.ts
@@ -1,0 +1,31 @@
+import { expectType } from 'tsd';
+import { Command, Option } from '..';
+
+// Doing end-to-end test, rather than checking created Option directly.
+
+if ('when createOption with boolean then type is boolean') {
+  const program = new Command();
+  const foo = program
+    .addOption(program.createOption('-f, --foo', 'decription'))
+    .opts()
+    .foo;
+  expectType<true | undefined>(foo);
+}
+
+if ('when createOption with required option-argument then type is string') {
+  const program = new Command();
+  const foo = program
+    .addOption(program.createOption('-f, --foo <value>', 'decription'))
+    .opts()
+    .foo;
+  expectType<string | undefined>(foo);
+}
+
+if ('when createOption with optional option-argument then type is string|true') {
+  const program = new Command();
+  const foo = program
+    .addOption(program.createOption('-f, --foo [value]', 'decription'))
+    .opts()
+    .foo;
+  expectType<string | true | undefined>(foo);
+}

--- a/tests/create-option.test-d.ts
+++ b/tests/create-option.test-d.ts
@@ -1,9 +1,9 @@
 import { expectType } from 'tsd';
-import { Command, Option } from '..';
+import { Command, createOption } from '..';
 
 // Doing end-to-end test, rather than checking created Option directly.
 
-if ('when createOption with boolean then type is boolean') {
+if ('when cmd.createOption with boolean then type is boolean') {
   const program = new Command();
   const foo = program
     .addOption(program.createOption('-f, --foo', 'decription'))
@@ -12,7 +12,7 @@ if ('when createOption with boolean then type is boolean') {
   expectType<true | undefined>(foo);
 }
 
-if ('when createOption with required option-argument then type is string') {
+if ('when cmd.createOption with required option-argument then type is string') {
   const program = new Command();
   const foo = program
     .addOption(program.createOption('-f, --foo <value>', 'decription'))
@@ -21,10 +21,37 @@ if ('when createOption with required option-argument then type is string') {
   expectType<string | undefined>(foo);
 }
 
-if ('when createOption with optional option-argument then type is string|true') {
+if ('when cmd.createOption with optional option-argument then type is string|true') {
   const program = new Command();
   const foo = program
     .addOption(program.createOption('-f, --foo [value]', 'decription'))
+    .opts()
+    .foo;
+  expectType<string | true | undefined>(foo);
+}
+
+if ('when global createOption with boolean then type is boolean') {
+  const program = new Command();
+  const foo = program
+    .addOption(createOption('-f, --foo', 'decription'))
+    .opts()
+    .foo;
+  expectType<true | undefined>(foo);
+}
+
+if ('when global createOption with required option-argument then type is string') {
+  const program = new Command();
+  const foo = program
+    .addOption(createOption('-f, --foo <value>', 'decription'))
+    .opts()
+    .foo;
+  expectType<string | undefined>(foo);
+}
+
+if ('when global createOption with optional option-argument then type is string|true') {
+  const program = new Command();
+  const foo = program
+    .addOption(createOption('-f, --foo [value]', 'decription'))
     .opts()
     .foo;
   expectType<string | true | undefined>(foo);


### PR DESCRIPTION
Add type inference for `createOption(usage)`, using same approach as `new Option(usage)`.