### PR TITLE
Add typing for processedArgs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -436,7 +436,7 @@ export class CommanderError extends Error {
   
   export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
     args: string[];
-    processedArgs: any[];
+    processedArgs: Args;
     commands: CommandUnknownOpts[];
     parent: CommandUnknownOpts | null;
   

--- a/tests/processed-args.test-d.ts
+++ b/tests/processed-args.test-d.ts
@@ -1,0 +1,58 @@
+import { expectType } from 'tsd';
+import { Command } from '..';
+
+// Doing a subset of the full tests in arguments.test-d.ts
+
+if ('when no arguments then empty array') {
+  const program = new Command();
+  const args = program
+    .parse()
+    .processedArgs;
+  expectType<[]>(args);
+}
+
+if ('when required argument then string element') {
+  const program = new Command();
+  const args = program
+    .argument('<value>')
+    .parse()
+    .processedArgs;
+  expectType<[string]>(args);
+}
+
+if ('when optional argument then string|undefined element') {
+  const program = new Command();
+  const args = program
+    .argument('[value]')
+    .parse()
+    .processedArgs;
+  expectType<[string| undefined]>(args);
+}
+
+if ('when variadic argument then string[] element') {
+  const program = new Command();
+  const args = program
+    .argument('<value...>')
+    .parse()
+    .processedArgs;
+  expectType<[string[]]>(args);
+}
+
+if ('when multiple arguments then multiple elements') {
+  const program = new Command();
+  const args = program
+    .argument('<value>')
+    .argument('[value]')
+    .parse()
+    .processedArgs;
+  expectType<[string, string | undefined]>(args);
+}
+
+if ('when custom argument processing then custom type') {
+  const program = new Command();
+  const args = program
+    .argument('<value>', 'description', parseFloat)
+    .parse()
+    .processedArgs;
+  expectType<[number]>(args);
+}


### PR DESCRIPTION
Already had the type available in the generic parameters, so easy definition. Add tests for the new typing.