### PR TITLE
Add typing for createArgument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -516,7 +516,7 @@ export class CommanderError extends Error {
      * See .argument() for creating an attached argument, which uses this routine to
      * create the argument. You can override createArgument to return a custom argument.
      */
-    createArgument(name: string, description?: string): Argument;
+    createArgument<Usage extends string>(name: Usage, description?: string): Argument<Usage>;
   
     /**
      * Define argument syntax for command.
@@ -1057,7 +1057,7 @@ export class CommanderError extends Error {
   
   export function createCommand(name?: string): Command;
   export function createOption(flags: string, description?: string): Option;
-  export function createArgument(name: string, description?: string): Argument;
+  export function createArgument<Usage extends string>(name: Usage, description?: string): Argument<Usage>;
   
   export const program: Command;
   

--- a/tests/create-argument.test-d.ts
+++ b/tests/create-argument.test-d.ts
@@ -1,0 +1,58 @@
+import { expectType } from 'tsd';
+import { Command, createArgument } from '..';
+
+// Doing end-to-end test, rather than checking created Argument directly.
+
+if ('when cmd.createArgument with required then type is string') {
+  const program = new Command();
+  program
+    .addArgument(program.createArgument('<value>'))
+    .action(arg => {
+      expectType<string>(arg)
+    });
+}
+
+if ('when cmd.createArgument with optional then type is string|undefined') {
+  const program = new Command();
+  program
+    .addArgument(program.createArgument('[value]'))
+    .action(arg => {
+      expectType<string | undefined>(arg)
+    });
+}
+
+if ('when cmd.createArgument with variadic then type is string[]') {
+  const program = new Command();
+  program
+    .addArgument(program.createArgument('<value...>'))
+    .action(arg => {
+      expectType<string[]>(arg)
+    });
+}
+
+if ('when global createArgument with required then type is string') {
+  const program = new Command();
+  program
+    .addArgument(createArgument('<value>'))
+    .action(arg => {
+      expectType<string>(arg)
+    });
+}
+
+if ('when global createArgument with optional then type is string|undefined') {
+  const program = new Command();
+  program
+    .addArgument(createArgument('[value]'))
+    .action(arg => {
+      expectType<string | undefined>(arg)
+    });
+}
+
+if ('when global createArgument with variadic then type is string[]') {
+  const program = new Command();
+  program
+    .addArgument(createArgument('<value...>'))
+    .action(arg => {
+      expectType<string[]>(arg)
+    });
+}


### PR DESCRIPTION
Add type inference for createArgument(usage), using same approach as new Argument(usage).