### PR TITLE
Tie version to commander

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # extra-typings for commander
 
+[![NPM Version](http://img.shields.io/npm/v/@commander-js/extra-typings.svg?style=flat)](https://www.npmjs.org/package/@commander-js/extra-typings)
+[![NPM Downloads](https://img.shields.io/npm/dm/@commander-js/extra-typings.svg?style=flat)](https://npmcharts.com/compare/@commander-js/extra-typings?minimal=true)
+
 This package offers experimental TypeScript typings for `commander` which infer strong types for:
 
 - all the parameters of the action handler, including the options
 - options returned by `.opts()`
 
-Limitations
-
-- the generics lead to some noisy types visible in editor and errors
-- some code changes for subclasses of `Command`, `Argument`, or `Option` (see [subclass.test-d.ts](./tests/subclass.test-d.ts))
-  - chaining methods which do type inference return base class rather than `this`
-  - subclass of `Command` returns base class not subclass from `.command(name)`
-  - type parameter needed for class declaration of subclass of `Option` and `Argument`
+The runtime is supplied by commander. This package is all about the typings.
 
 Usage
 
@@ -19,9 +16,17 @@ Usage
 - install `commander`, if not already installed (peer dependency)
 - in code import from `@commander-js/extra-typings` instead of `commander`
 
-The runtime is supplied by commander. This package is all about the typings.
+The installed version of this package should match the major and minor version numbers of the installed commander package, but the patch version number is independent (following pattern used by [Definitely Typed](https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library)).
 
 Credit: this builds on work by @PaperStrike in <https://github.com/tj/commander.js/pull/1758>
+
+## Limitations
+
+- the generics lead to some noisy types visible in editor and errors
+- some minor code changes required for subclasses of `Command`, `Argument`, or `Option` (see [subclass.test-d.ts](./tests/subclass.test-d.ts))
+  - chaining methods which do type inference return base class rather than `this`
+  - subclass of `Command` returns base class not subclass from `.command(name)`
+  - type parameter needed for class declaration of subclass of `Option` and `Argument`
 
 ## Usage tips
 
@@ -57,4 +62,3 @@ const program = new Command()
   .option('-d, --debug'); // program type includes chained options and arguments
 const options = program.opts(); // smart type
 ```
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,20 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "0.3.0",
+  "version": "9.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commander-js/extra-typings",
-      "version": "0.3.0",
+      "version": "9.4.0",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.7.16"
-      },
       "devDependencies": {
+        "@types/node": "^18.7.16",
         "tsd": "^0.22.0",
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
-        "commander": "9.x"
+        "commander": "9.4.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -192,7 +190,8 @@
     "node_modules/@types/node": {
       "version": "18.7.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
-      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg=="
+      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -1484,7 +1483,8 @@
     "@types/node": {
       "version": "18.7.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
-      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg=="
+      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "0.3.0",
+  "version": "9.4.0",
   "description": "Infer strong typings for commander options and action handlers",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/commander-js/extra-typings#readme",
   "peerDependencies": {
-    "commander": "9.x"
+    "commander": "9.4.x"
   },
   "devDependencies": {
     "@types/node": "^18.7.16",

--- a/tests/commander.test-d.ts
+++ b/tests/commander.test-d.ts
@@ -39,7 +39,7 @@ expectType<commander.Argument>(commander.createArgument('<foo>'));
 // Command properties
 expectType<string[]>(program.args);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-expectType<any[]>(program.processedArgs);
+expectType<[]>(program.processedArgs);
 expectType<commander.CommandUnknownOpts[]>(program.commands);
 expectType<commander.CommandUnknownOpts | null>(program.parent);
 


### PR DESCRIPTION
- make some improvements to README
- tie this package version number to the commander version the same way as Definitely Typed does

I don't have any other work planned, and no feedback so far. I am thinking of making a release with a "real" version number so it matches Commander? 

The README does continue to say "experimental".