### PR TITLE
Add esm.mjs to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/commander-js/extra-typings.git"
   },
   "files": [
+    "esm.mjs",
     "index.js",
     "index.d.ts"
   ],


### PR DESCRIPTION
Missing `esm.mjs` from `files` in `package.json`, so not included in published package.

Fixes #15 