### PR TITLE
Add getOptionValueSourceWithGlobals

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -775,11 +775,17 @@ export class CommanderError extends Error {
      setOptionValueWithSource(key: string, value: unknown, source: OptionValueSource): this;
   
     /**
-     * Retrieve option value source.
+     * Get source of option value.
      */
      getOptionValueSource<K extends keyof Opts>(key: K): OptionValueSource | undefined;
      getOptionValueSource(key: string): OptionValueSource | undefined;
   
+    /**
+     * Get source of option value. See also .optsWithGlobals().
+     */
+    getOptionValueSourceWithGlobals<K extends keyof Opts>(key: K): OptionValueSource | undefined;
+    getOptionValueSourceWithGlobals(key: string): OptionValueSource | undefined;
+
     /**
      * Alter parsing of short flags with optional values.
      *

--- a/tests/commander.test-d.ts
+++ b/tests/commander.test-d.ts
@@ -189,6 +189,9 @@ expectChainedCommand(program.setOptionValueWithSource('example', [], 'cli'));
 // getOptionValueSource
 expectType<commander.OptionValueSource | undefined>(program.getOptionValueSource('example'));
 
+// getOptionValueSourceWithGlobals
+expectType<commander.OptionValueSource | undefined>(program.getOptionValueSourceWithGlobals('example'));
+
 // combineFlagAndOptionalValue
 expectChainedCommand(program.combineFlagAndOptionalValue());
 expectChainedCommand(program.combineFlagAndOptionalValue(false));


### PR DESCRIPTION
Add upcoming `getOptionValueSourceWithGlobals ` method from Commander: https://github.com/tj/commander.js/pull/1832