### PR TITLE
Add support for showing global options in Help

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -358,7 +358,8 @@ export class CommanderError extends Error {
     helpWidth?: number;
     sortSubcommands: boolean;
     sortOptions: boolean;
-  
+    showGlobalOptions: boolean;
+
     constructor();
   
     /** Get the command term to show in the list of subcommands. */
@@ -383,6 +384,8 @@ export class CommanderError extends Error {
     visibleCommands(cmd: CommandUnknownOpts): CommandUnknownOpts[];
     /** Get an array of the visible options. Includes a placeholder for the implicit help option, if there is one. */
     visibleOptions(cmd: CommandUnknownOpts): Option[];
+    /** Get an array of the visible global options. (Not including help.) */
+    visibleGlobalOptions(cmd: CommandUnknownOpts): Option[];
     /** Get an array of the arguments which have descriptions. */
     visibleArguments(cmd: CommandUnknownOpts): Argument[];
   
@@ -390,6 +393,8 @@ export class CommanderError extends Error {
     longestSubcommandTermLength(cmd: CommandUnknownOpts, helper: Help): number;
     /** Get the longest option term length. */
     longestOptionTermLength(cmd: CommandUnknownOpts, helper: Help): number;
+    /** Get the longest global option term length. */
+    longestGlobalOptionTermLength(cmd: CommandUnknownOpts, helper: Help): number;
     /** Get the longest argument term length. */
     longestArgumentTermLength(cmd: CommandUnknownOpts, helper: Help): number;
     /** Calculate the pad width from the maximum term length. */

--- a/tests/commander.test-d.ts
+++ b/tests/commander.test-d.ts
@@ -385,6 +385,7 @@ const helperArgument = new commander.Argument('<file>');
 expectType<number | undefined>(helper.helpWidth);
 expectType<boolean>(helper.sortSubcommands);
 expectType<boolean>(helper.sortOptions);
+expectType<boolean>(helper.showGlobalOptions);
 
 expectType<string>(helper.subcommandTerm(helperCommand));
 expectType<string>(helper.commandUsage(helperCommand));
@@ -397,10 +398,12 @@ expectType<string>(helper.argumentDescription(helperArgument));
 
 expectType<commander.CommandUnknownOpts[]>(helper.visibleCommands(helperCommand));
 expectType<commander.Option[]>(helper.visibleOptions(helperCommand));
+expectType<commander.Option[]>(helper.visibleGlobalOptions(helperCommand));
 expectType<commander.Argument[]>(helper.visibleArguments(helperCommand));
 
 expectType<number>(helper.longestSubcommandTermLength(helperCommand, helper));
 expectType<number>(helper.longestOptionTermLength(helperCommand, helper));
+expectType<number>(helper.longestGlobalOptionTermLength(helperCommand, helper));
 expectType<number>(helper.longestArgumentTermLength(helperCommand, helper));
 expectType<number>(helper.padWidth(helperCommand, helper));
 


### PR DESCRIPTION
Add upcoming support for showing global options in Help from Commander: https://github.com/tj/commander.js/pull/1828