### PR TITLE
Pass arguments through create routines to object constructors

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -1,4 +1,4 @@
-import commander from './index.js';
+import extraTypingsCommander from './index.js';
 
 // wrapper to provide named exports for ESM.
 export const {
@@ -13,4 +13,4 @@ export const {
   Argument,
   Option,
   Help
-} = commander;
+} = extraTypingsCommander;

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ exports.InvalidArgumentError = commander.InvalidArgumentError;
 exports.InvalidOptionArgumentError = commander.InvalidArgumentError; // Deprecated
 exports.Option = commander.Option;
 
-// In Commander, the create routines end up calling through to the matching
+// In Commander, the create routines end up being aliases for the matching
 // methods on the global program due to the (deprecated) legacy default export.
 // Here we roll our own, the way Commander might in future.
 exports.createArgument = (name) => new commander.Argument(name);

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ exports.InvalidArgumentError = commander.InvalidArgumentError;
 exports.InvalidOptionArgumentError = commander.InvalidArgumentError; // Deprecated
 exports.Option = commander.Option;
 
-exports.createArgument = () => new commander.Argument();
-exports.createCommand = () => new commander.Command();
-exports.createOption = () => new commander.Option();
+// In Commander, the create routines end up calling through to the matching
+// methods on the global program due to the (deprecated) legacy default export.
+// Here we roll our own, the way Commander might in future.
+exports.createArgument = (name) => new commander.Argument(name);
+exports.createCommand = (flags, description) => new commander.Command(flags, description);
+exports.createOption = (name) => new commander.Option(name, description);


### PR DESCRIPTION
Problem: the create routines like `createCommand` were ignoring client arguments and just calling the relevant constructor without any arguments.

Solution: pass through the arguments.

See: #22