### PR TITLE
Run tests before publish, but not during install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tsd && jest",
-    "prepublish": "npm run --silent test"
+    "prepublishOnly": "npm run --silent test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

Gosh darn it, `prepublish` is still running on install, so can't fix up the install and add Commander before running the tests on old versions of Node.js!
- https://docs.npmjs.com/cli/v9/using-npm/scripts#prepare-and-prepublish

## Solution

Switch to `prepublishOnly`. (Won't run tests before pack, but we don't use pack directly.)