### PR TITLE
feat: mark action as explicitly accepting promises

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -664,7 +664,7 @@ export class CommanderError extends Error {
      *
      * @returns `this` command for chaining
      */
-    action(fn: (...args: [...Args, Opts, this]) => void): this;
+    action(fn: (...args: [...Args, Opts, this]) => void | Promise<void>): this;
 
     /**
      * Define option with `flags`, `description` and optional


### PR DESCRIPTION
while typescript allows passing in `() => Promise<void>` as a callback for `() => void`, typescript-eslint catches those as `Promise returned in function argument where a void return was expected.eslint@typescript-eslint/no-misused-promises` (in its type-checking rules)

this change allows passing in async functions to `action()`, knowing the returned promise by `parseAsync()` will be handled by the caller.