### PR TITLE
Add explicit file for esm type definitions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Credit: this builds on work by @PaperStrike in <https://github.com/tj/commander.
 
 The types are built up as the options and arguments are defined. The usage pattern for action handlers is easy. Just chain the action handler after the options and arguments.
 
-```js
+```typescript
 import { program } from '@commander-js/extra-typings';
 
 program.command('print')
@@ -45,7 +45,7 @@ program.command('print')
 
 For working with a single command without an action handler, the configuration need to be done at the same time as the variable is declared.
 
-```js
+```typescript
 import { Command } from '@commander-js/extra-typings';
 
 // broken pattern
@@ -54,11 +54,20 @@ program.option('-d, --debug'); // adding option does not change type of program
 const options = program.opts(); // dumb type
 ```
 
-```js
+```typescript
 import { Command } from '@commander-js/extra-typings';
 
 // working pattern
 const program = new Command()
   .option('-d, --debug'); // program type includes chained options and arguments
 const options = program.opts(); // smart type
+```
+
+Use a "const assertion" on the choices to narrow the option type from `string`:
+
+```typescript
+const program = new Command()
+  .addOption(new Option('--drink-size <size>').choices(['small', 'medium', 'large'] as const))
+  .parse();
+const drinkSize = program.opts().drinkSize; // "small" | "medium" | "large" | undefined
 ```


### PR DESCRIPTION
# Pull Request

## Problem

We were not technically correct with assuming that the cjs definitions file also covers the esm entry point. There should be a separate definitions file for each of cjs and esm. This is so TypeScript can be sure the types are appropriate for the context.

See #40

## Solution

Add an explicit esm definitions file, which just reexports the cjs types. 

Since the files are all at the top level, remove the explicit `"types"` entry and let TypeScript find the definitions file beside the entry point.

In addition, we had an export entry for `esm.mjs` itself. This was to match the original way esm was supported in Commander before conditional types, and is not needed for this newer repo.

## ChangeLog

- Added: explicit types file for esm
- Removed: direct export of `esm.mjs`

