### PR TITLE
Add explicit file for esm type definitions

### DIFF
--- a/esm.d.mts
+++ b/esm.d.mts
@@ -1,0 +1,2 @@
+// Just reexport the types from cjs definition file.
+export * from './index.js';

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   },
   "files": [
     "esm.mjs",
+    "esm.d.mts",
     "index.js",
     "index.d.ts"
   ],
   "type": "commonjs",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
       "require": "./index.js",
       "import": "./esm.mjs"
     },

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     ".": {
       "require": "./index.js",
       "import": "./esm.mjs"
-    },
-    "./esm.mjs": "./esm.mjs"
+    }
   },
   "types": "index.d.ts",
   "tsd": {


### PR DESCRIPTION
# Pull Request

## Problem

We were not technically correct with assuming that the cjs definitions file also covers the esm entry point. There should be a separate definitions file for each of cjs and esm. This is so TypeScript can be sure the types are appropriate for the context.

See #40

## Solution

Add an explicit esm definitions file, which just reexports the cjs types. 

Since the files are all at the top level, remove the explicit `"types"` entry and let TypeScript find the definitions file beside the entry point.

In addition, we had an export entry for `esm.mjs` itself. This was to match the original way esm was supported in Commander before conditional types, and is not needed for this newer repo.

## ChangeLog

- Added: explicit types file for esm
- Removed: direct export of `esm.mjs`

