### PR TITLE
Add Command.options property, and make it and Command.commands readonly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -453,7 +453,8 @@ export class CommanderError extends Error {
   export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
     args: string[];
     processedArgs: Args;
-    commands: CommandUnknownOpts[];
+    readonly commands: readonly CommandUnknownOpts[];
+    readonly options: readonly Option[];
     parent: CommandUnknownOpts | null;
   
     constructor(name?: string);

--- a/tests/commander.test-d.ts
+++ b/tests/commander.test-d.ts
@@ -40,7 +40,8 @@ expectType<commander.Argument>(commander.createArgument('<foo>'));
 expectType<string[]>(program.args);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 expectType<[]>(program.processedArgs);
-expectType<commander.CommandUnknownOpts[]>(program.commands);
+expectType<readonly commander.CommandUnknownOpts[]>(program.commands);
+expectType<readonly commander.Option[]>(program.options);
 expectType<commander.CommandUnknownOpts | null>(program.parent);
 
 // version


### PR DESCRIPTION
# Pull Request

## Problem

Add `Command.options`, which was added to Commander in https://github.com/tj/commander.js/pull/1827

See: #46

## Solution

Simple change to match Commander. 

For Commander, we landed this in a major release as could break some clients. For same reason I suggest we postpone landing this until Commander 12 (having missed it until now). 

## ChangeLog

- add: add `Command.options` property
- change: make `Command.commands` a readonly property