### PR TITLE
Preserve option typings when adding arguments to Command

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -549,13 +549,13 @@ export class CommanderError extends Error {
      * @returns `this` command for chaining
      */
     argument<S extends string, T>(
-        flags: S, description: string, fn: (value: string, previous: T) => T): Command<[...Args, InferArgument<S, undefined, T>]>;
+        flags: S, description: string, fn: (value: string, previous: T) => T): Command<[...Args, InferArgument<S, undefined, T>], Opts>;
     argument<S extends string, T>(
-        flags: S, description: string, fn: (value: string, previous: T) => T, defaultValue: T): Command<[...Args, InferArgument<S, T, T>]>;
+        flags: S, description: string, fn: (value: string, previous: T) => T, defaultValue: T): Command<[...Args, InferArgument<S, T, T>], Opts>;
     argument<S extends string>(
-        usage: S, description?: string): Command<[...Args, InferArgument<S, undefined>]>;
+        usage: S, description?: string): Command<[...Args, InferArgument<S, undefined>], Opts>;
     argument<S extends string, DefaultT>(
-        usage: S, description: string, defaultValue: DefaultT): Command<[...Args, InferArgument<S, DefaultT>]>;
+        usage: S, description: string, defaultValue: DefaultT): Command<[...Args, InferArgument<S, DefaultT>], Opts>;
     
     /**
      * Define argument syntax for command, adding a prepared argument.
@@ -563,7 +563,7 @@ export class CommanderError extends Error {
      * @returns `this` command for chaining
      */
     addArgument<Usage extends string, DefaultT, CoerceT, ArgRequired extends boolean|undefined, ChoicesT>(
-      arg: Argument<Usage, DefaultT, CoerceT, ArgRequired, ChoicesT>): Command<[...Args, InferArgument<Usage, DefaultT, CoerceT, ArgRequired, ChoicesT>]>;
+      arg: Argument<Usage, DefaultT, CoerceT, ArgRequired, ChoicesT>): Command<[...Args, InferArgument<Usage, DefaultT, CoerceT, ArgRequired, ChoicesT>], Opts>;
 
   
     /**
@@ -578,7 +578,7 @@ export class CommanderError extends Error {
      *
      * @returns `this` command for chaining
      */
-    arguments<Names extends string>(args: Names): Command<[...Args, ...InferArguments<Names>]>;
+    arguments<Names extends string>(args: Names): Command<[...Args, ...InferArguments<Names>], Opts>;
 
   
     /**

--- a/tests/arguments.test-d.ts
+++ b/tests/arguments.test-d.ts
@@ -385,3 +385,28 @@ expectType<('C')>(
     .parse()
     .processedArgs[0]
 )
+
+// adding argument preserves options
+expectType<({ example?: true })>(
+  program
+    .option('--example')
+    .argument('<arg>', 'arg description')
+    .parse()
+    .opts()
+)
+
+expectType<({ example?: true })>(
+  program
+    .option('--example')
+    .arguments('<arg1> [arg2]')
+    .parse()
+    .opts()
+)
+
+expectType<({ example?: true })>(
+  program
+    .option('--example')
+    .addArgument(new Argument('<arg>'))
+    .parse()
+    .opts()
+)


### PR DESCRIPTION
# Pull Request

## Problem

Adding an argument to a command after adding an option was forgetting the option typings.

## Solution

Add `Opts` to template return type.

## ChangeLog

- fix: preserve option typings when adding arguments to `Command`