### PR TITLE
Add options and registeredArguments properties to Command

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -168,8 +168,6 @@ type InferOptions<Options, Usage extends string, DefaultT, CoerceT, Mandatory ex
       : InferOptionsFlag<Options, Usage, '', never, PresetT, DefaultT, CoerceT, Mandatory, ChoicesT>;
 
 export type CommandUnknownOpts = Command<unknown[], OptionValues>;
-// export type OptionUnknown = Option<'', unknown, unknown, unknown, boolean, unknown>;
-// export type ArgumentUnknown = Argument<'', unknown, unknown, boolean, unknown>;
 
 // ----- full copy of normal commander typings from here down, with extra type inference -----
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -168,6 +168,8 @@ type InferOptions<Options, Usage extends string, DefaultT, CoerceT, Mandatory ex
       : InferOptionsFlag<Options, Usage, '', never, PresetT, DefaultT, CoerceT, Mandatory, ChoicesT>;
 
 export type CommandUnknownOpts = Command<unknown[], OptionValues>;
+// export type OptionUnknown = Option<'', unknown, unknown, unknown, boolean, unknown>;
+// export type ArgumentUnknown = Argument<'', unknown, unknown, boolean, unknown>;
 
 // ----- full copy of normal commander typings from here down, with extra type inference -----
 
@@ -454,6 +456,8 @@ export class CommanderError extends Error {
     args: string[];
     processedArgs: Args;
     commands: CommandUnknownOpts[];
+    readonly options: readonly Option[];
+    readonly registeredArguments: readonly Argument[];
     parent: CommandUnknownOpts | null;
   
     constructor(name?: string);

--- a/tests/commander.test-d.ts
+++ b/tests/commander.test-d.ts
@@ -41,6 +41,8 @@ expectType<string[]>(program.args);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 expectType<[]>(program.processedArgs);
 expectType<commander.CommandUnknownOpts[]>(program.commands);
+expectType<readonly commander.Option[]>(program.options);
+expectType<readonly commander.Argument[]>(program.registeredArguments);
 expectType<commander.CommandUnknownOpts | null>(program.parent);
 
 // version


### PR DESCRIPTION
# Pull Request

## Problem

Commander exposes `Command.options` and `Command.registeredArguments`.

- https://github.com/tj/commander.js/pull/1827
- https://github.com/tj/commander.js/pull/2010 

## Solution

Just a simple addition, without trying to be fancy about using `unknown` in the generic parameters.

## ChangeLog

Added
- `options` property on Command
- `registeredArguments` property on `Command`
