### PR TITLE
Update CHANGELOG for v12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The version numbering does not follow semantic versioning but instead aligns wit
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
+## [12.0.0] (2023-02-04)
+
+### Changed
+
+- update `peerDependencies` to `commander@12.0.x`, which requires Node.js v18 or higher
+
 ## [12.0.0-1] (2023-11-13)
 
 ### Fixed
@@ -145,6 +151,7 @@ The version numbering does not follow semantic versioning but instead aligns wit
 - inferred types for `.action()`
 - inferred types for `.opts()`
 
+[12.0.0]: https://github.com/commander-js/extra-typings/compare/v12.0.0...v11.0.0
 [12.0.0-1]: https://github.com/commander-js/extra-typings/compare/v12.0.0-0...v12.0.0-1
 [12.0.0-0]: https://github.com/commander-js/extra-typings/compare/v11.1.0...v12.0.0-0
 [11.1.0]: https://github.com/commander-js/extra-typings/compare/v11.0.0...v11.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "12.0.0-1",
+  "version": "12.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commander-js/extra-typings",
-      "version": "12.0.0-1",
+      "version": "12.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.6",
         "@types/node": "^18.7.16",
-        "commander": "~12.0.0-0",
+        "commander": "~12.0.0",
         "jest": "^29.3.1",
         "ts-jest": "^29.0.5",
         "tsd": "^0.22.0",
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
-        "commander": "12.0.0-0"
+        "commander": "~12.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1575,9 +1575,9 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "12.0.0-0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0-0.tgz",
-      "integrity": "sha512-UsCJj6ASq58nS+xEF4P/eCKYaBC938xOTQMJnTEdUOn0EZ63zHjr4ewwbf++T/w7kdpY57dW2Ff4Jsk2xL+aUg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -5570,9 +5570,9 @@
       "dev": true
     },
     "commander": {
-      "version": "12.0.0-0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0-0.tgz",
-      "integrity": "sha512-UsCJj6ASq58nS+xEF4P/eCKYaBC938xOTQMJnTEdUOn0EZ63zHjr4ewwbf++T/w7kdpY57dW2Ff4Jsk2xL+aUg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
       "dev": true
     },
     "concat-map": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "12.0.0-1",
+  "version": "12.0.0",
   "description": "Infer strong typings for commander options and action handlers",
   "main": "index.js",
   "scripts": {
@@ -45,12 +45,12 @@
     ]
   },
   "peerDependencies": {
-    "commander": "12.0.0-0"
+    "commander": "~12.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",
     "@types/node": "^18.7.16",
-    "commander": "~12.0.0-0",
+    "commander": "~12.0.0",
     "jest": "^29.3.1",
     "ts-jest": "^29.0.5",
     "tsd": "^0.22.0",


### PR DESCRIPTION
Simple changelog entries since leaving out the details where just matching Commander changes.

We will need one last commit to update the peer dependency after Command 12.0.0 is released.