### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+Old versions receive security updates for six months.
+
+| Version | Supported                                  |
+| ------- | ------------------------------------------ |
+| 12.x    | :white_check_mark:                         |
+| 11.x    | :white_check_mark: support ends 2024-07-03 |
+| < 11    | :x:                                        |
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please use the
+[Tidelift security contact](https://tidelift.com/security).
+Tidelift will coordinate the fix and disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,7 @@
 
 ## Supported Versions
 
-Old versions receive security updates for six months.
-
-| Version | Supported                                  |
-| ------- | ------------------------------------------ |
-| 12.x    | :white_check_mark:                         |
-| 11.x    | :white_check_mark: support ends 2024-07-03 |
-| < 11    | :x:                                        |
+Security updates are supported for the current version and the previous major version.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
I am going through the process of "lifting" this project on Tidelift.
NB: There is not any current income!
You can apply as a lifter now too @abetomo , or leave it until later.

I copied the security policy from Commander, but have a question about it and Tidelift.

Tidelift has some simple options to describe the "security maintenance plan". I came up with six month support for older versions, which is not covered by their "common" plans. We could perhaps switch to support for one previous major version. This would usually be about a year since we do major versions to drop unsupported versions of node. (And the previous version of Commander we are supporting would usually include one unsupported version of node.)

The "one previous version" is nice and simple to describe, which I like. Alone it doesn't give any fixed minimum or maximum duration for support of the old version which I see as a small downside (say if we released a new major version every week!).

Shall I have a go at rewording so our policy covers "previous version" without a maximum time?