### PR TITLE
Bump version and update CHANGELOG for 12.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The version numbering does not follow semantic versioning but instead aligns wit
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
+## [12.0.1] (2023-03-02)
+
+### Changed
+
+- include implicit `this` in parameters for action handler callback [#59]
+
 ## [12.0.0] (2023-02-04)
 
 ### Changed
@@ -151,7 +157,8 @@ The version numbering does not follow semantic versioning but instead aligns wit
 - inferred types for `.action()`
 - inferred types for `.opts()`
 
-[12.0.0]: https://github.com/commander-js/extra-typings/compare/v12.0.0...v11.0.0
+[12.0.1]: https://github.com/commander-js/extra-typings/compare/v12.0.0...v12.0.1
+[12.0.0]: https://github.com/commander-js/extra-typings/compare/v11.0.0...v12.0.0
 [12.0.0-1]: https://github.com/commander-js/extra-typings/compare/v12.0.0-0...v12.0.0-1
 [12.0.0-0]: https://github.com/commander-js/extra-typings/compare/v11.1.0...v12.0.0-0
 [11.1.0]: https://github.com/commander-js/extra-typings/compare/v11.0.0...v11.1.0
@@ -177,3 +184,4 @@ The version numbering does not follow semantic versioning but instead aligns wit
 [#48]: https://github.com/commander-js/extra-typings/pull/48
 [#49]: https://github.com/commander-js/extra-typings/pull/49
 [#50]: https://github.com/commander-js/extra-typings/pull/50
+[#59]: https://github.com/commander-js/extra-typings/pull/59

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commander-js/extra-typings",
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Infer strong typings for commander options and action handlers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Prepare a little release to add implicit `this` parameter for action handler callback (#59). Includes the addition of a Security Policy (#60).