### PR TITLE
Refactor eslint configs inside tseslint.config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,10 +5,17 @@ const tseslint = require('typescript-eslint');
 const prettier = require('eslint-config-prettier');
 //const jsdoc = require('eslint-plugin-jsdoc');
 
-// Using tseslint config helper to customise its setup the tseslint way.
+// Only run tseslint on the files that we have included for TypeScript.
 const tsconfigTsFiles = ['**/*.{ts,mts}'];
 const tsconfigJsFiles = ['**.{js,mjs}'];
-const tseslintConfigs = tseslint.config(
+
+// Using tseslint.config adds some type safety and `extends` to simplify customising config array.
+module.exports = tseslint.config(
+  // Add recommended rules.
+  esLintjs.configs.recommended,
+  // jsdoc.configs['flat/recommended'],
+  jest.configs['flat/recommended'],
+  // tseslint with different setup for js/ts
   {
     files: tsconfigJsFiles,
     extends: [...tseslint.configs.recommended],
@@ -20,13 +27,6 @@ const tseslintConfigs = tseslint.config(
     files: tsconfigTsFiles,
     extends: [...tseslint.configs.recommended],
   },
-);
-
-module.exports = [
-  esLintjs.configs.recommended,
-  // jsdoc.configs['flat/recommended'],
-  jest.configs['flat/recommended'],
-  ...tseslintConfigs,
   prettier, // Do Prettier last so it can override previous configs.
 
   // Customise rules.
@@ -50,7 +50,6 @@ module.exports = [
     files: ['tests/*.{js,mjs,cjs,ts,mts,cts}'],
     rules: {
       'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
     },
   },
   {
@@ -62,6 +61,7 @@ module.exports = [
   {
     files: [...tsconfigTsFiles, ...tsconfigJsFiles],
     rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/ban-ts-comment': [
         'error',
         {
@@ -73,4 +73,4 @@ module.exports = [
       ],
     },
   },
-];
+);


### PR DESCRIPTION
This is a minor refactor. I didn't fully appreciate tseslint.config() first time around, and just used it for the tseslint related configs. In fact tseslint.config() adds some type safety to all the configs and typescript-eslint recommends using it.