### PR TITLE
Remove unimplemented fullDescription from TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -495,11 +495,6 @@ export class Option<
   env(name: string): this;
 
   /**
-   * Calculate the full description, including defaultValue etc.
-   */
-  fullDescription(): string;
-
-  /**
    * Set the custom handler for processing CLI option arguments into option values.
    */
   argParser<T>(

--- a/tests/commander.test-d.ts
+++ b/tests/commander.test-d.ts
@@ -608,9 +608,6 @@ expectType<commander.Option>(baseOption.preset('abc'));
 // env
 expectType<commander.Option>(baseOption.env('PORT'));
 
-// fullDescription
-expectType<string>(baseOption.fullDescription());
-
 // argParser
 expectType<commander.Option>(
   baseOption.argParser((value: string) => parseInt(value)),


### PR DESCRIPTION
Matching Commander tidy: https://github.com/tj/commander.js/pull/2191

Changelog:

- Deleted: remove unimplemented Option.fullDescription from TypeScript definition