### PR TITLE
Prepare for 12.1.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The version numbering does not follow semantic versioning but instead aligns wit
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
+## [12.1.0] (2024-05-18)
+
+### Changed
+
+- use ESLint for linting ([#65])
+- format source files with Prettier ([#66])
+
+### Removed
+
+- removed unimplemented Option.fullDescription from TypeScript definition ([#70])
+
+
 ## [12.0.1] (2023-03-02)
 
 ### Changed
@@ -157,6 +169,7 @@ The version numbering does not follow semantic versioning but instead aligns wit
 - inferred types for `.action()`
 - inferred types for `.opts()`
 
+[12.1.0]: https://github.com/commander-js/extra-typings/compare/v12.0.1...v12.1.0
 [12.0.1]: https://github.com/commander-js/extra-typings/compare/v12.0.0...v12.0.1
 [12.0.0]: https://github.com/commander-js/extra-typings/compare/v11.0.0...v12.0.0
 [12.0.0-1]: https://github.com/commander-js/extra-typings/compare/v12.0.0-0...v12.0.0-1
@@ -185,3 +198,7 @@ The version numbering does not follow semantic versioning but instead aligns wit
 [#49]: https://github.com/commander-js/extra-typings/pull/49
 [#50]: https://github.com/commander-js/extra-typings/pull/50
 [#59]: https://github.com/commander-js/extra-typings/pull/59
+
+[#65]: https://github.com/commander-js/extra-typings/pull/65
+[#66]: https://github.com/commander-js/extra-typings/pull/66
+[#70]: https://github.com/commander-js/extra-typings/pull/70

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "12.0.1",
+  "version": "12.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commander-js/extra-typings",
-      "version": "12.0.1",
+      "version": "12.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.6",
         "@types/node": "^20.11.7",
-        "commander": "~12.0.0",
+        "commander": "~12.1.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jest": "^27.9.0",
@@ -24,7 +24,7 @@
         "typescript-eslint": "^7.5.0"
       },
       "peerDependencies": {
-        "commander": "~12.0.0"
+        "commander": "~12.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2166,9 +2166,9 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
-      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "12.0.1",
+  "version": "12.1.0",
   "description": "Infer strong typings for commander options and action handlers",
   "main": "index.js",
   "scripts": {
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/commander-js/extra-typings#readme",
   "peerDependencies": {
-    "commander": "~12.0.0"
+    "commander": "~12.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",
     "@types/node": "^20.11.7",
-    "commander": "~12.0.0",
+    "commander": "~12.1.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "^27.9.0",


### PR DESCRIPTION
Update CHANGELOG and version for v12.1.0, to go out after Commander v12.1.0.
Added note 22 to testing matrix.

Note: build failure expected since Commander v12.1.0 not released yet.

Reminder to self: do an install after Commander is out to update `package-lock.js` with correct hash etc.