### PR TITLE
chore: use `@jest/globals` instead of `@types/jest`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('jest').Config} */
 const config = {
   collectCoverage: true,
-  injectGlobals: true,
+  injectGlobals: false,
   testEnvironment: 'node',
   transform: {
     '^.+\\.tsx?$': ['ts-jest'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
+/** @type {import('jest').Config} */
 const config = {
-  testEnvironment: 'node',
   collectCoverage: true,
+  injectGlobals: true,
+  testEnvironment: 'node',
   transform: {
     '^.+\\.tsx?$': ['ts-jest'],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/jest": "^29.2.6",
+        "@jest/globals": "^29.3.1",
         "@types/node": "^20.11.7",
         "commander": "~12.1.0",
         "eslint": "^8.57.0",
@@ -965,6 +965,7 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -1321,16 +1322,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "29.5.12",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
-      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
-      "dev": true,
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/json-schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -965,7 +965,6 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "commander": "~12.1.0"
   },
   "devDependencies": {
-    "@types/jest": "^29.2.6",
+    "@jest/globals": "^29.3.1",
     "@types/node": "^20.11.7",
     "commander": "~12.1.0",
     "eslint": "^8.57.0",

--- a/tests/global-createArgument.test.ts
+++ b/tests/global-createArgument.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from '@jest/globals';
 import { createArgument } from '..';
 
 test('when createArgument without description then argument has name', () => {

--- a/tests/global-createCommand.test.ts
+++ b/tests/global-createCommand.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from '@jest/globals';
 import { createCommand } from '..';
 
 test('when createCommand without name then command has empty name', () => {

--- a/tests/global-createOption.test.ts
+++ b/tests/global-createOption.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from '@jest/globals';
 import { createOption } from '..';
 
 test('when createOption without description then option has flags', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "lib": ["es6"],
-    "types": ["node", "jest"],
+    "types": ["node"],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,


### PR DESCRIPTION
# Pull Request

## Problem

The `@types/jest` is redundant, because Jest ships typings via `@jest/globals` package. (By the way, Jest repo has type tests with more than 1000 assertions.)

Main difference: testing APIs must be explicitly imported from `@jest/globals`, instead of being globally available. This means that in a way `@types/jest` is polluting the global namespace. For instance, currently it is possible to use Jest's `test()` helper in type tests. That does not sound right, or?

## Solution

Replaced `@types/jest` with imports from `@jest/globals`.

## ChangeLog

N/A
