### PR TITLE
Remove dummy if statements

### DIFF
--- a/tests/assignment.test-d.ts
+++ b/tests/assignment.test-d.ts
@@ -1,12 +1,14 @@
 import { expectAssignable, expectNotAssignable } from 'tsd';
 import { Command, CommandUnknownOpts, Option } from '..';
 
-if ('when assign Command to CommandUnknownOpts then no error') {
+// 'when assign Command to CommandUnknownOpts then no error'
+{
   const c = new Command();
   expectAssignable<CommandUnknownOpts>(c);
 }
 
-if ('when assign CommandUnknownOpts to Command then error') {
+// 'when assign CommandUnknownOpts to Command then error'
+{
   const custom: CommandUnknownOpts = new Command();
   expectNotAssignable<Command>(custom);
 }

--- a/tests/command-unknown-opts.test-d.ts
+++ b/tests/command-unknown-opts.test-d.ts
@@ -3,7 +3,8 @@ import { expectType } from 'tsd';
 
 // Fallback location for CommandUnknownOpts if not better file for the test.
 
-if ('when CommandUnknownOpts then opts().foo is allowed but unknown') {
+// 'when CommandUnknownOpts then opts().foo is allowed but unknown'
+{
   const program: CommandUnknownOpts = new Command();
   const v = program.opts()['foo'];
   expectType<unknown>(v);

--- a/tests/create-argument.test-d.ts
+++ b/tests/create-argument.test-d.ts
@@ -3,49 +3,56 @@ import { Command, createArgument } from '..';
 
 // Doing end-to-end test, rather than checking created Argument directly.
 
-if ('when cmd.createArgument with required then type is string') {
+// 'when cmd.createArgument with required then type is string'
+{
   const program = new Command();
   program.addArgument(program.createArgument('<value>')).action((arg) => {
     expectType<string>(arg);
   });
 }
 
-if ('when cmd.createArgument with optional then type is string|undefined') {
+// ('when cmd.createArgument with optional then type is string|undefined'
+{
   const program = new Command();
   program.addArgument(program.createArgument('[value]')).action((arg) => {
     expectType<string | undefined>(arg);
   });
 }
 
-if ('when cmd.createArgument with variadic then type is string[]') {
+// 'when cmd.createArgument with variadic then type is string[]'
+{
   const program = new Command();
   program.addArgument(program.createArgument('<value...>')).action((arg) => {
     expectType<string[]>(arg);
   });
 }
 
-if ('when global createArgument with required then type is string') {
+// 'when global createArgument with required then type is string'
+{
   const program = new Command();
   program.addArgument(createArgument('<value>')).action((arg) => {
     expectType<string>(arg);
   });
 }
 
-if ('when global createArgument with optional then type is string|undefined') {
+// 'when global createArgument with optional then type is string|undefined'
+{
   const program = new Command();
   program.addArgument(createArgument('[value]')).action((arg) => {
     expectType<string | undefined>(arg);
   });
 }
 
-if ('when global createArgument with variadic then type is string[]') {
+// 'when global createArgument with variadic then type is string[]'
+{
   const program = new Command();
   program.addArgument(createArgument('<value...>')).action((arg) => {
     expectType<string[]>(arg);
   });
 }
 
-if ('when global createArgument with const choices then type is string union') {
+// 'when global createArgument with const choices then type is string union'
+{
   const program = new Command();
   program
     .addArgument(createArgument('<value>').choices(['A', 'B', 'C'] as const))
@@ -54,9 +61,8 @@ if ('when global createArgument with const choices then type is string union') {
     });
 }
 
-if (
-  'when global createArgument with variadic and const choices then type is array of string union'
-) {
+// 'when global createArgument with variadic and const choices then type is array of string union'
+{
   const program = new Command();
   program
     .addArgument(createArgument('<value...>').choices(['A', 'B', 'C'] as const))

--- a/tests/create-option.test-d.ts
+++ b/tests/create-option.test-d.ts
@@ -3,7 +3,8 @@ import { Command, createOption } from '..';
 
 // Doing end-to-end test, rather than checking created Option directly.
 
-if ('when cmd.createOption with boolean then type is boolean') {
+// 'when cmd.createOption with boolean then type is boolean'
+{
   const program = new Command();
   const foo = program
     .addOption(program.createOption('-f, --foo', 'decription'))
@@ -11,7 +12,8 @@ if ('when cmd.createOption with boolean then type is boolean') {
   expectType<true | undefined>(foo);
 }
 
-if ('when cmd.createOption with required option-argument then type is string') {
+// 'when cmd.createOption with required option-argument then type is string'
+{
   const program = new Command();
   const foo = program
     .addOption(program.createOption('-f, --foo <value>', 'decription'))
@@ -19,9 +21,8 @@ if ('when cmd.createOption with required option-argument then type is string') {
   expectType<string | undefined>(foo);
 }
 
-if (
-  'when cmd.createOption with optional option-argument then type is string|true'
-) {
+// 'when cmd.createOption with optional option-argument then type is string|true'
+{
   const program = new Command();
   const foo = program
     .addOption(program.createOption('-f, --foo [value]', 'decription'))
@@ -29,7 +30,8 @@ if (
   expectType<string | true | undefined>(foo);
 }
 
-if ('when global createOption with boolean then type is boolean') {
+// 'when global createOption with boolean then type is boolean'
+{
   const program = new Command();
   const foo = program
     .addOption(createOption('-f, --foo', 'decription'))
@@ -37,9 +39,8 @@ if ('when global createOption with boolean then type is boolean') {
   expectType<true | undefined>(foo);
 }
 
-if (
-  'when global createOption with required option-argument then type is string'
-) {
+// 'when global createOption with required option-argument then type is string'
+{
   const program = new Command();
   const foo = program
     .addOption(createOption('-f, --foo <value>', 'decription'))
@@ -47,9 +48,8 @@ if (
   expectType<string | undefined>(foo);
 }
 
-if (
-  'when global createOption with optional option-argument then type is string|true'
-) {
+// 'when global createOption with optional option-argument then type is string|true'
+{
   const program = new Command();
   const foo = program
     .addOption(createOption('-f, --foo [value]', 'decription'))
@@ -57,7 +57,8 @@ if (
   expectType<string | true | undefined>(foo);
 }
 
-if ('when global createOption with const choices then type is string union') {
+// 'when global createOption with const choices then type is string union'
+{
   const program = new Command();
   const foo = program
     .addOption(
@@ -71,9 +72,8 @@ if ('when global createOption with const choices then type is string union') {
   expectType<'A' | 'B' | 'C' | undefined>(foo);
 }
 
-if (
-  'when global createOption with variadic and const choices then type is string union array'
-) {
+// 'when global createOption with variadic and const choices then type is string union array'
+{
   const program = new Command();
   const foo = program
     .addOption(

--- a/tests/help.test-d.ts
+++ b/tests/help.test-d.ts
@@ -6,9 +6,8 @@ import { Help, Command, CommandUnknownOpts, Option } from '..';
 // Reminder: we pass the command into the Help methods using JavaScript so
 // no type checking there, but subclass is TypeScript.
 
-if (
-  'when subclass Help method with cmd arg as CommandUnknownOpts then no error'
-) {
+// 'when subclass Help method with cmd arg as CommandUnknownOpts then no error'
+{
   class MyHelp extends Help {
     subcommandTerm(cmd: CommandUnknownOpts) {
       return cmd.name();
@@ -16,7 +15,8 @@ if (
   }
 }
 
-if ('when subclass Help method with cmd arg as Command then no error') {
+// 'when subclass Help method with cmd arg as Command then no error'
+{
   class MyHelp extends Help {
     subcommandTerm(cmd: Command) {
       return cmd.name();
@@ -24,19 +24,22 @@ if ('when subclass Help method with cmd arg as Command then no error') {
   }
 }
 
-if ('when pass type Command to visibleOptions then no error') {
+// 'when pass type Command to visibleOptions then no error'
+{
   const program = new Command().option('--foo').argument('<one>');
   program.createHelp().visibleOptions(program);
 }
 
-if ('when pass type CommandUnknownOpts to visibleOptions then no error') {
+// 'when pass type CommandUnknownOpts to visibleOptions then no error'
+{
   const program: CommandUnknownOpts = new Command()
     .option('--foo')
     .argument('<one>');
   program.createHelp().visibleOptions(program);
 }
 
-if ('when call visibleCommands then returns CommandUnknownOpts[]') {
+// 'when call visibleCommands then returns CommandUnknownOpts[]'
+{
   const program = new Command().option('--foo').argument('<one>');
   const vo = program.createHelp().visibleCommands(program);
   expectType<CommandUnknownOpts[]>(vo);

--- a/tests/hook.test-d.ts
+++ b/tests/hook.test-d.ts
@@ -1,7 +1,8 @@
 import { expectType } from 'tsd';
 import { Command } from '..';
 
-if ('when add preAction hook then thisCommand strongly typed') {
+// 'when add preAction hook then thisCommand strongly typed'
+{
   const program = new Command()
     .option('-f, --foo <value>')
     .hook('preAction', (thisCommand, actionCommand) => {
@@ -10,7 +11,8 @@ if ('when add preAction hook then thisCommand strongly typed') {
     });
 }
 
-if ('when add preAction hook then activeCommand strongly typed') {
+// 'when add preAction hook then activeCommand strongly typed'
+{
   const program = new Command()
     .option('-f, --foo <value>')
     .hook('preAction', (thisCommand, activeCommand) => {
@@ -19,7 +21,8 @@ if ('when add preAction hook then activeCommand strongly typed') {
     });
 }
 
-if ('when add postAction hook then thisCommand strongly typed') {
+// 'when add postAction hook then thisCommand strongly typed'
+{
   const program = new Command()
     .option('-f, --foo <value>')
     .hook('postAction', (thisCommand, actionCommand) => {
@@ -28,7 +31,8 @@ if ('when add postAction hook then thisCommand strongly typed') {
     });
 }
 
-if ('when add postAction hook then activeCommand strongly typed') {
+// 'when add postAction hook then activeCommand strongly typed'
+{
   const program = new Command()
     .option('-f, --foo <value>')
     .hook('postAction', (thisCommand, activeCommand) => {
@@ -37,7 +41,8 @@ if ('when add postAction hook then activeCommand strongly typed') {
     });
 }
 
-if ('when add preSubcommand hook then thisCommand strongly typed') {
+// 'when add preSubcommand hook then thisCommand strongly typed'
+{
   const program = new Command()
     .option('-f, --foo <value>')
     .hook('preSubcommand', (thisCommand, actionCommand) => {
@@ -46,7 +51,8 @@ if ('when add preSubcommand hook then thisCommand strongly typed') {
     });
 }
 
-if ('when add preSubcommand hook then activeCommand strongly typed') {
+// 'when add preSubcommand hook then activeCommand strongly typed'
+{
   const program = new Command()
     .option('-f, --foo <value>')
     .hook('preSubcommand', (thisCommand, activeCommand) => {

--- a/tests/option-value.test-d.ts
+++ b/tests/option-value.test-d.ts
@@ -1,14 +1,16 @@
 import { expectType } from 'tsd';
 import { Command } from '..';
 
-if ('when getOptionValue is unknown then key is unknown') {
+// 'when getOptionValue is unknown then key is unknown'
+{
   const program = new Command().option('-f, --foo');
 
   const v = program.getOptionValue('bar');
   expectType<unknown>(v);
 }
 
-if ('when getOptionValue result is typed then key is known') {
+// 'when getOptionValue result is typed then key is known'
+{
   const program = new Command().option('-f, --foo');
   const v = program.getOptionValue('foo');
   expectType<true | undefined>(v);

--- a/tests/processed-args.test-d.ts
+++ b/tests/processed-args.test-d.ts
@@ -3,31 +3,36 @@ import { Command } from '..';
 
 // Doing a subset of the full tests in arguments.test-d.ts
 
-if ('when no arguments then empty array') {
+// 'when no arguments then empty array'
+{
   const program = new Command();
   const args = program.parse().processedArgs;
   expectType<[]>(args);
 }
 
-if ('when required argument then string element') {
+// 'when required argument then string element'
+{
   const program = new Command();
   const args = program.argument('<value>').parse().processedArgs;
   expectType<[string]>(args);
 }
 
-if ('when optional argument then string|undefined element') {
+// 'when optional argument then string|undefined element'
+{
   const program = new Command();
   const args = program.argument('[value]').parse().processedArgs;
   expectType<[string | undefined]>(args);
 }
 
-if ('when variadic argument then string[] element') {
+// 'when variadic argument then string[] element'
+{
   const program = new Command();
   const args = program.argument('<value...>').parse().processedArgs;
   expectType<[string[]]>(args);
 }
 
-if ('when multiple arguments then multiple elements') {
+// 'when multiple arguments then multiple elements'
+{
   const program = new Command();
   const args = program
     .argument('<value>')
@@ -36,7 +41,8 @@ if ('when multiple arguments then multiple elements') {
   expectType<[string, string | undefined]>(args);
 }
 
-if ('when custom argument processing then custom type') {
+// 'when custom argument processing then custom type'
+{
   const program = new Command();
   const args = program
     .argument('<value>', 'description', parseFloat)

--- a/tests/subclass.test-d.ts
+++ b/tests/subclass.test-d.ts
@@ -21,9 +21,8 @@ class MyCommand extends Command {
   }
 }
 
-if (
-  'when add subcommand to MyCommand then return type is not MyCommand (limitation)'
-) {
+// 'when add subcommand to MyCommand then return type is not MyCommand (limitation)'
+{
   const myProgram = new MyCommand();
   const mySub = myProgram.command('sub');
   // Breaking: lost automatic custom typing of subcommands
@@ -31,22 +30,23 @@ if (
   mySub.myFunction();
 }
 
-if (
-  'when call chaining method using inference on MyCommand then return type not MyCommand (limitation)'
-) {
+// 'when call chaining method using inference on MyCommand then return type not MyCommand (limitation)'
+{
   new MyCommand().myFunction();
   // Breaking: lost subclass when chain
   // @ts-expect-error because lost subclass and so myFunction unknown
   new MyCommand().option('-f').myFunction();
 }
 
-if ('when add option to MyCommand then option type inferred') {
+// 'when add option to MyCommand then option type inferred'
+{
   const program = new MyCommand().option('-f, --foo', 'foo description');
   const foo = program.opts().foo;
   expectType<true | undefined>(foo);
 }
 
-if ('when add MyOption to Command then option type inferred') {
+// 'when add MyOption to Command then option type inferred'
+{
   const program = new Command().addOption(
     new MyOption('-f, --foo <value>', 'foo description').makeOptionMandatory(),
   );
@@ -54,9 +54,8 @@ if ('when add MyOption to Command then option type inferred') {
   expectType<string>(foo);
 }
 
-if (
-  'when call chaining method using inference on MyOption then return type not MyOption (limitation)'
-) {
+// 'when call chaining method using inference on MyOption then return type not MyOption (limitation)'
+{
   new MyOption('-f, --foo').myFunction();
   // Breaking: lost subclass when chain
   // @ts-expect-error because lost subclass and so myFunction unknown


### PR DESCRIPTION
# Pull Request

I was using an if statement for a block in the type tests like:
```
if ('test description') {
   ....
   expectedType(...);
}
```

to mirror the Jest test layout:
```
it ('test description') {
   ....
   expect(...);
}
```


## Problem

TypeScript started complaining about the truthy value (string) used for the `if` expression.

## Solution

Move the test description to a comment. Keep the blocks so have scoped local variables.
