### PR TITLE
Strongly typed optsWithGlobals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,26 +3,15 @@ const esLintjs = require('@eslint/js');
 const jest = require('eslint-plugin-jest');
 const tseslint = require('typescript-eslint');
 const prettier = require('eslint-config-prettier');
-//const jsdoc = require('eslint-plugin-jsdoc');
 
-// Only run tseslint on the files that we have included for TypeScript.
+// Simpler setup than in Commander as not running TypeScript over .js files.
 const tsconfigTsFiles = ['**/*.{ts,mts}'];
-const tsconfigJsFiles = ['**.{js,mjs}'];
 
 // Using tseslint.config adds some type safety and `extends` to simplify customising config array.
 module.exports = tseslint.config(
   // Add recommended rules.
   esLintjs.configs.recommended,
-  // jsdoc.configs['flat/recommended'],
   jest.configs['flat/recommended'],
-  // tseslint with different setup for js/ts
-  {
-    files: tsconfigJsFiles,
-    extends: [...tseslint.configs.recommended],
-    rules: {
-      '@typescript-eslint/no-var-requires': 'off', // (tseslint does not autodetect commonjs context )
-    },
-  },
   {
     files: tsconfigTsFiles,
     extends: [...tseslint.configs.recommended],
@@ -34,11 +23,6 @@ module.exports = tseslint.config(
     files: ['**/*.{js,mjs,cjs}', '**/*.{ts,mts,cts}'],
     rules: {
       'no-else-return': ['error', { allowElseIf: false }],
-
-      // 'jsdoc/tag-lines': 'off',
-      // 'jsdoc/require-jsdoc': 'off',
-      // 'jsdoc/require-param-description': 'off',
-      // 'jsdoc/require-returns-description': 'off',
     },
     languageOptions: {
       globals: {
@@ -59,7 +43,7 @@ module.exports = tseslint.config(
     },
   },
   {
-    files: [...tsconfigTsFiles, ...tsconfigJsFiles],
+    files: [...tsconfigTsFiles],
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/ban-ts-comment': [

--- a/examples/assemble-program.ts
+++ b/examples/assemble-program.ts
@@ -1,0 +1,11 @@
+import { Command } from '../index.js';
+
+// Example of strongly typed globals in a subcommand which is added to program using .addCommand().
+// Declare factory function for root Command in separate file from adding subcommands to avoid circular dependencies.
+
+export function createProgram() {
+  const program = new Command().option('-g, --global');
+  return program;
+}
+
+export type ProgramOpts = ReturnType<ReturnType<typeof createProgram>['opts']>;

--- a/examples/assemble-sub.ts
+++ b/examples/assemble-sub.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+
+// Example of strongly typed globals in a subcommand which is added to program using .addCommand().
+
+import { Command } from '../index.js';
+import { type ProgramOpts } from './assemble-program.js';
+
+export function createSub() {
+  const program = new Command<[], {}, ProgramOpts>('sub').option('-l, --local');
+  const optsWithGlobals = program.optsWithGlobals();
+  return program;
+}
+
+export type SubOpts = ReturnType<typeof createSub>['opts'];

--- a/examples/assemble.ts
+++ b/examples/assemble.ts
@@ -1,0 +1,11 @@
+import { createProgram, type ProgramOpts } from './assemble-program';
+import { createSub, type SubOpts } from './assemble-sub';
+
+// Example of strongly typed globals in a subcommand which is added to program using .addCommand().
+
+export function AssembleProgram() {
+  const program = createProgram();
+  const subCommand = createSub();
+  program.addCommand(subCommand);
+  return program;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1089,7 +1089,7 @@ export class Command<
   /**
    * Get source of option value. See also .optsWithGlobals().
    */
-  getOptionValueSourceWithGlobals<K extends keyof Opts>(
+  getOptionValueSourceWithGlobals<K extends keyof (Opts & GlobalOpts)>(
     key: K,
   ): OptionValueSource | undefined;
   getOptionValueSourceWithGlobals(key: string): OptionValueSource | undefined;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,6 @@
+// eslint complains about {} as a type, but hard to be more accurate.
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+
 type TrimRight<S extends string> = S extends `${infer R} ` ? TrimRight<R> : S;
 type TrimLeft<S extends string> = S extends ` ${infer R}` ? TrimLeft<R> : S;
 type Trim<S extends string> = TrimLeft<TrimRight<S>>;
@@ -313,7 +316,7 @@ type InferOptions<
         ChoicesT
       >;
 
-export type CommandUnknownOpts = Command<unknown[], OptionValues>;
+export type CommandUnknownOpts = Command<unknown[], OptionValues, OptionValues>;
 
 // ----- full copy of normal commander typings from here down, with extra type inference -----
 
@@ -631,9 +634,11 @@ export type OptionValueSource =
 
 export type OptionValues = Record<string, unknown>;
 
-// eslint unimpressed with `OptionValues = {}`, but not sure what to use instead.
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
+export class Command<
+  Args extends any[] = [],
+  Opts extends OptionValues = {},
+  GlobalOpts extends OptionValues = {},
+> {
   args: string[];
   processedArgs: Args;
   readonly commands: readonly CommandUnknownOpts[];
@@ -679,7 +684,7 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
   command<Usage extends string>(
     nameAndArgs: Usage,
     opts?: CommandOptions,
-  ): Command<[...InferCommandArguments<Usage>]>;
+  ): Command<[...InferCommandArguments<Usage>], {}, Opts & GlobalOpts>;
   /**
    * Define a command, implemented in a separate executable file.
    *
@@ -750,22 +755,22 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
     flags: S,
     description: string,
     fn: (value: string, previous: T) => T,
-  ): Command<[...Args, InferArgument<S, undefined, T>], Opts>;
+  ): Command<[...Args, InferArgument<S, undefined, T>], Opts, GlobalOpts>;
   argument<S extends string, T>(
     flags: S,
     description: string,
     fn: (value: string, previous: T) => T,
     defaultValue: T,
-  ): Command<[...Args, InferArgument<S, T, T>], Opts>;
+  ): Command<[...Args, InferArgument<S, T, T>], Opts, GlobalOpts>;
   argument<S extends string>(
     usage: S,
     description?: string,
-  ): Command<[...Args, InferArgument<S, undefined>], Opts>;
+  ): Command<[...Args, InferArgument<S, undefined>], Opts, GlobalOpts>;
   argument<S extends string, DefaultT>(
     usage: S,
     description: string,
     defaultValue: DefaultT,
-  ): Command<[...Args, InferArgument<S, DefaultT>], Opts>;
+  ): Command<[...Args, InferArgument<S, DefaultT>], Opts, GlobalOpts>;
 
   /**
    * Define argument syntax for command, adding a prepared argument.
@@ -782,7 +787,8 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
     arg: Argument<Usage, DefaultT, CoerceT, ArgRequired, ChoicesT>,
   ): Command<
     [...Args, InferArgument<Usage, DefaultT, CoerceT, ArgRequired, ChoicesT>],
-    Opts
+    Opts,
+    GlobalOpts
   >;
 
   /**
@@ -799,7 +805,7 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
    */
   arguments<Names extends string>(
     args: Names,
-  ): Command<[...Args, ...InferArguments<Names>], Opts>;
+  ): Command<[...Args, ...InferArguments<Names>], Opts, GlobalOpts>;
 
   /**
    * Customise or override default help command. By default a help command is automatically added if your command has subcommands.
@@ -938,23 +944,31 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
   option<S extends string>(
     usage: S,
     description?: string,
-  ): Command<Args, InferOptions<Opts, S, undefined, undefined, false>>;
+  ): Command<
+    Args,
+    InferOptions<Opts, S, undefined, undefined, false>,
+    GlobalOpts
+  >;
   option<S extends string, DefaultT extends string | boolean | string[] | []>(
     usage: S,
     description?: string,
     defaultValue?: DefaultT,
-  ): Command<Args, InferOptions<Opts, S, DefaultT, undefined, false>>;
+  ): Command<
+    Args,
+    InferOptions<Opts, S, DefaultT, undefined, false>,
+    GlobalOpts
+  >;
   option<S extends string, T>(
     usage: S,
     description: string,
     parseArg: (value: string, previous: T) => T,
-  ): Command<Args, InferOptions<Opts, S, undefined, T, false>>;
+  ): Command<Args, InferOptions<Opts, S, undefined, T, false>, GlobalOpts>;
   option<S extends string, T>(
     usage: S,
     description: string,
     parseArg: (value: string, previous: T) => T,
     defaultValue?: T,
-  ): Command<Args, InferOptions<Opts, S, T, T, false>>;
+  ): Command<Args, InferOptions<Opts, S, T, T, false>, GlobalOpts>;
 
   /**
    * Define a required option, which must have a value after parsing. This usually means
@@ -965,7 +979,11 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
   requiredOption<S extends string>(
     usage: S,
     description?: string,
-  ): Command<Args, InferOptions<Opts, S, undefined, undefined, true>>;
+  ): Command<
+    Args,
+    InferOptions<Opts, S, undefined, undefined, true>,
+    GlobalOpts
+  >;
   requiredOption<
     S extends string,
     DefaultT extends string | boolean | string[],
@@ -973,18 +991,22 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
     usage: S,
     description?: string,
     defaultValue?: DefaultT,
-  ): Command<Args, InferOptions<Opts, S, DefaultT, undefined, true>>;
+  ): Command<
+    Args,
+    InferOptions<Opts, S, DefaultT, undefined, true>,
+    GlobalOpts
+  >;
   requiredOption<S extends string, T>(
     usage: S,
     description: string,
     parseArg: (value: string, previous: T) => T,
-  ): Command<Args, InferOptions<Opts, S, undefined, T, true>>;
+  ): Command<Args, InferOptions<Opts, S, undefined, T, true>, GlobalOpts>;
   requiredOption<S extends string, T, D extends T>(
     usage: S,
     description: string,
     parseArg: (value: string, previous: T) => T,
     defaultValue?: D,
-  ): Command<Args, InferOptions<Opts, S, D, T, true>>;
+  ): Command<Args, InferOptions<Opts, S, D, T, true>, GlobalOpts>;
 
   /**
    * Factory routine to create a new unattached option.
@@ -1014,7 +1036,8 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
     option: Option<Usage, PresetT, DefaultT, CoerceT, Mandatory, ChoicesT>,
   ): Command<
     Args,
-    InferOptions<Opts, Usage, DefaultT, CoerceT, Mandatory, PresetT, ChoicesT>
+    InferOptions<Opts, Usage, DefaultT, CoerceT, Mandatory, PresetT, ChoicesT>,
+    GlobalOpts
   >;
 
   /**
@@ -1176,7 +1199,7 @@ export class Command<Args extends any[] = [], Opts extends OptionValues = {}> {
   /**
    * Return an object containing merged local and global option values as key-value pairs.
    */
-  optsWithGlobals<T extends OptionValues>(): T;
+  optsWithGlobals(): Resolve<Opts & GlobalOpts>;
 
   /**
    * Set the description.

--- a/index.js
+++ b/index.js
@@ -18,9 +18,6 @@ exports.InvalidArgumentError = commander.InvalidArgumentError;
 exports.InvalidOptionArgumentError = commander.InvalidArgumentError; // Deprecated
 exports.Option = commander.Option;
 
-// In Commander, the create routines end up being aliases for the matching
-// methods on the global program due to the (deprecated) legacy default export.
-// Here we roll our own, the way Commander might in future.
 exports.createCommand = (name) => new commander.Command(name);
 exports.createOption = (flags, description) =>
   new commander.Option(flags, description);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "ts-jest": "^29.0.5",
         "tsd": "^0.30.4",
         "typescript": "^5.3.3",
-        "typescript-eslint": "^7.5.0"
+        "typescript-eslint": "^8.11.0"
       },
       "peerDependencies": {
         "commander": "~12.1.0"
@@ -1382,6 +1382,8 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.5.0.tgz",
       "integrity": "sha512-HpqNTH8Du34nLxbKgVMGljZMG0rJd2O9ecvr2QLYp+7512ty1j42KnsFwspPXg1Vh8an9YImf6CokUBltisZFQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
         "@typescript-eslint/scope-manager": "7.5.0",
@@ -1417,6 +1419,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1429,6 +1433,8 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1443,13 +1449,17 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.5.0.tgz",
       "integrity": "sha512-cj+XGhNujfD2/wzR1tabNsidnYRaFfEkcULdcIyVBYcXjBvBKOes+mpMBP7hMpOyk+gBcfXsrg4NBGAStQyxjQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.5.0",
         "@typescript-eslint/types": "7.5.0",
@@ -1478,6 +1488,8 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
       "integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.5.0",
         "@typescript-eslint/visitor-keys": "7.5.0"
@@ -1495,6 +1507,8 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
       "integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/typescript-estree": "7.5.0",
         "@typescript-eslint/utils": "7.5.0",
@@ -1522,6 +1536,8 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
       "integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
@@ -1535,6 +1551,8 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
       "integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.5.0",
         "@typescript-eslint/visitor-keys": "7.5.0",
@@ -1563,6 +1581,8 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1572,6 +1592,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1584,6 +1606,8 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1599,6 +1623,8 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1613,13 +1639,17 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
       "integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
@@ -1645,6 +1675,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1657,6 +1689,8 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1671,13 +1705,17 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
       "integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.5.0",
         "eslint-visitor-keys": "^3.4.1"
@@ -5611,29 +5649,256 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.5.0.tgz",
-      "integrity": "sha512-eKhF39LRi2xYvvXh3h3S+mCxC01dZTIZBlka25o39i81VeQG+OZyfC4i2GEDspNclMRdXkg9uGhmvWMhjph2XQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.11.0.tgz",
+      "integrity": "sha512-cBRGnW3FSlxaYwU8KfAewxFK5uzeOAp0l2KebIlPDOT5olVi65KDG/yjBooPBG0kGW/HLkoz1c/iuBFehcS3IA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "7.5.0",
-        "@typescript-eslint/parser": "7.5.0",
-        "@typescript-eslint/utils": "7.5.0"
+        "@typescript-eslint/eslint-plugin": "8.11.0",
+        "@typescript-eslint/parser": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.11.0.tgz",
+      "integrity": "sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/type-utils": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.11.0.tgz",
+      "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.11.0.tgz",
+      "integrity": "sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.11.0.tgz",
+      "integrity": "sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.11.0.tgz",
+      "integrity": "sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.11.0.tgz",
+      "integrity": "sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.11.0.tgz",
+      "integrity": "sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.11.0.tgz",
+      "integrity": "sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.11.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "ts-jest": "^29.0.5",
     "tsd": "^0.30.4",
     "typescript": "^5.3.3",
-    "typescript-eslint": "^7.5.0"
+    "typescript-eslint": "^8.11.0"
   }
 }

--- a/tests/commander.test-d.ts
+++ b/tests/commander.test-d.ts
@@ -384,9 +384,18 @@ expectAssignable<commander.OptionValues>(opts);
 
 // optsWithGlobals
 const optsWithGlobals = program.optsWithGlobals();
-expectType<commander.OptionValues>(optsWithGlobals);
-expectType(optsWithGlobals.foo);
-expectType(optsWithGlobals.bar);
+{
+  const rootCommand = new commander.Command().option('-b');
+  const subCommand = rootCommand.command('sub').option('-s <value>');
+  const optsWithGlobals = subCommand.optsWithGlobals();
+  expectType<{ s?: string; b?: true }>(optsWithGlobals);
+  // nested subcommands
+  const nestedSubCommand = subCommand.command('subsub').option('-o [value]');
+  const nestedOptsWithGlobals = nestedSubCommand.optsWithGlobals();
+  expectType<{ s?: string; b?: true; o?: string | true }>(
+    nestedOptsWithGlobals,
+  );
+}
 
 // optsWithGlobals with generics
 // Breaking change: user supplied type no longer supported this way


### PR DESCRIPTION
# Pull Request

## Problem

`.optsWithGlobals()` and `.getOptionValueSourceWithGlobals()` are weakly typed and not using globals.

## Solution

Add `Command<>` generic for `GlobalOpts`.

- `.optsWithGlobals()` is strongly typed
- `.getOptionValueSourceWithGlobals()` is weakly typed. Get autocompletion for known options, but can enter anything, like with the other `...Source...` routines.

On the way I upgraded eslint because I noticed `@typescript-eslint/ban-types` was changing to `@typescript-eslint/no-empty-object-type`. And simplified `eslint.config.js` to avoid bogus TypeScript errors from `.js` files. (Apologies for the extra changes. I did make them separate commits.)

## ChangeLog

- strongly type `.optsWithGlobals()` to include inferred globals
- weakly type `.getOptionValueSourceWithGlobals()` to include inferred globals
