### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ Use a "const assertion" on the choices to narrow the option type from `string`:
 
 ```typescript
 const program = new Command()
-  .addOption(new Option('--drink-size <size>').choices(['small', 'medium', 'large'] as const))
-  .parse();
+  .addOption(
+    new Option('--drink-size <size>')
+      .choices(['small', 'medium', 'large'] as const)
+      // if you want to provide a default option, also add a const assertion to it
+      .default('medium' as const)
+  ).parse();
 const drinkSize = program.opts().drinkSize; // "small" | "medium" | "large" | undefined
 ```


### PR DESCRIPTION
# Pull Request

## Problem
When setting a `default` on an option with choices, the inferred type degrades back to `string`. I took me a few minutes to figure out this was because of the `default` parameter in the first place.

## Solution
Adding this to the appropriate section of the readme might help someone with the same issue along in the future.

## ChangeLog
Add note about type inference for option with `choices` and `default`.