### PR TITLE
Support dual long options for Commander v13.1

### DIFF
--- a/tests/options.test-d.ts
+++ b/tests/options.test-d.ts
@@ -190,6 +190,9 @@ expectType<{ debug?: true }>(us6);
 const us7 = program.addOption(new Option('-d --debug')).opts();
 expectType<{ debug?: true }>(us7);
 
+const us8 = program.addOption(new Option('--db, --debug')).opts();
+expectType<{ debug?: true }>(us8);
+
 // choices
 
 // narrows required value to given choices


### PR DESCRIPTION
## Problem

Commander v13.1 will add support for dual long options, which was not previously considered.

## Solution

The option name inference actually works fine. Add a test to confirm.

