### PR TITLE
add parseArg to Argument class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -815,12 +815,12 @@ export class Command<
   argument<S extends string, T>(
     flags: S,
     description: string,
-    fn: (value: string, previous: T) => T,
+    parseArg: (value: string, previous: T) => T,
   ): Command<[...Args, InferArgument<S, undefined, T>], Opts, GlobalOpts>;
   argument<S extends string, T>(
     flags: S,
     description: string,
-    fn: (value: string, previous: T) => T,
+    parseArg: (value: string, previous: T) => T,
     defaultValue: T,
   ): Command<[...Args, InferArgument<S, T, T>], Opts, GlobalOpts>;
   argument<S extends string>(

--- a/index.d.ts
+++ b/index.d.ts
@@ -368,6 +368,7 @@ export class Argument<
   variadic: boolean;
   defaultValue?: any;
   defaultValueDescription?: string;
+  parseArg?: <T>(value: string, previous: T) => T;
   argChoices?: string[];
 
   /**


### PR DESCRIPTION
## Problem
Missing `parseArg` property on `Arguments` class

## Solution
Adding the missing property to the class

## ChangeLog
Add `parseArg` to property to `Arguments` class
Rename `fn` parameter in `argument` method to `parseArg` to be inline with the `option` method