### PR TITLE
Export types used in public methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ type InferArgumentTypeResolvedRequired<
   : InferArgumentOptionalType<Value, DefaultT, CoerceT, ChoicesT>;
 
 // Resolve whether argument required, and strip []/<> from around value.
-type InferArgument<
+export type InferArgument<
   S extends string,
   DefaultT = undefined,
   CoerceT = undefined,
@@ -104,11 +104,12 @@ type InferArgument<
         ChoicesT
       >; // the implementation fallback is treat as <required>
 
-type InferArguments<S extends string> = S extends `${infer First} ${infer Rest}`
-  ? [InferArgument<First>, ...InferArguments<TrimLeft<Rest>>]
-  : [InferArgument<S>];
+export type InferArguments<S extends string> =
+  S extends `${infer First} ${infer Rest}`
+    ? [InferArgument<First>, ...InferArguments<TrimLeft<Rest>>]
+    : [InferArgument<S>];
 
-type InferCommandArguments<S extends string> =
+export type InferCommandArguments<S extends string> =
   S extends `${string} ${infer Args}` ? InferArguments<TrimLeft<Args>> : [];
 
 type FlagsToFlag<Flags extends string> =
@@ -272,7 +273,7 @@ type InferOptionsFlag<
 >;
 
 // Split up Usage into Flags and Value
-type InferOptions<
+export type InferOptions<
   Options,
   Usage extends string,
   DefaultT,


### PR DESCRIPTION
## Problem

To override class methods, authors may need access to the types used for parameters or return types

I was conservative in what we exported at first so we could make changes, but there is a need for these.

Related: 
- https://github.com/commander-js/extra-typings/pull/62#issue-2124114498
- https://github.com/commander-js/extra-typings/pull/62#issuecomment-2585855395
- https://github.com/commander-js/extra-typings/issues/32

Possible future eslint rule to enforce this: https://github.com/typescript-eslint/typescript-eslint/issues/7670

## Solution

Add export for the `InferX` helpers used in public methods

## ChangeLog

- Added: export `InferArgument`, `InferArguments`, `InferCommandArguments`, and `InferOptions`