### PR TITLE
Configure target branch for dependabot and add npm ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
+  - package-ecosystem: "npm"
+    target-branch: "develop"
+    directory: "/"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "github-actions"
-    target-branch: "main"
+    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Add target branch, and add `package-ecosystem: "npm"` with same setup as Commander (monthly checks).