### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      # group simple version updates, leave major updates and security updates as single pull requests
+      minor-and-patch:
+        update-types:
+          - "patch"
+          - "minor"
+        applies-to:
+          - "version-updates"
   - package-ecosystem: "github-actions"
     target-branch: "develop"
     directory: "/"


### PR DESCRIPTION
I find the large number of individual Pull Requests opened by Dependabot a bit annoying. I just saw that they can be grouped!

This PR is intended to leave major updates and security updates individual, and group all the minor and patch ordinary version updates together.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#prioritizing-meaningful-updates