### PR TITLE
minor change in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1461,7 +1461,7 @@ export class Command<
    */
   outputHelp(context?: HelpContext): void;
   /** @deprecated since v7 */
-  outputHelp(cb?: (str: string) => string): void;
+  outputHelp(cb: (str: string) => string): void;
 
   /**
    * Return command help documentation.
@@ -1488,7 +1488,7 @@ export class Command<
    */
   help(context?: HelpContext): never;
   /** @deprecated since v7 */
-  help(cb?: (str: string) => string): never;
+  help(cb: (str: string) => string): never;
 
   /**
    * Add additional text to be displayed with the built-in help.


### PR DESCRIPTION
Fllow up from https://github.com/tj/commander.js/pull/2427#issuecomment-3336312975

## Problem

No problem, just a subtlety in the typings. The deprecated versions of help and outputHelp should not include the parameter-less version to make it entirely clear that only the callback variant itself is deprecated.## Solution

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
