### PR TITLE
Change version numbers to prerelease 15.0.0-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ const options = program.opts(); // smart type
 
 ## Ambient module setup
 
-An alternative approach is to setup `@commander-js/extra-typings` as an ambient module and a development-only dependency. We only worked
-this out recently so it isn't being promoted as the suggested method yet!
+An alternative approach is to setup `@commander-js/extra-typings` as an ambient module and a development-only dependency.
 
 Add a simple ambient module file to your project to use the enhanced typings instead of the default typings:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "14.0.0",
+  "version": "15.0.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commander-js/extra-typings",
-      "version": "14.0.0",
+      "version": "15.0.0-0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.1",
-        "commander": "~14.0.0",
+        "commander": "~15.0.0-0",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^10.0.1",
         "globals": "^17.0.0",
@@ -20,7 +20,7 @@
         "typescript-eslint": "^8.11.0"
       },
       "peerDependencies": {
-        "commander": "~14.0.0"
+        "commander": "~15.0.0-0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -433,6 +433,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -650,6 +651,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -860,13 +862,13 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0-0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0-0.tgz",
+      "integrity": "sha512-R2Kbbun8cjOe1aTbX4elymOwNvIdWenwSZl++AeuCu8nBGvJO5qCEwZ8Wa/8GMg5TXj/dBcPiQm/l1T9DO+Ryg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -1012,6 +1014,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2621,6 +2624,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2718,6 +2722,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "14.0.0",
+  "version": "15.0.0-0",
   "description": "Infer strong typings for commander options and action handlers",
   "main": "index.js",
   "scripts": {
@@ -43,11 +43,11 @@
   },
   "homepage": "https://github.com/commander-js/extra-typings#readme",
   "peerDependencies": {
-    "commander": "~14.0.0"
+    "commander": "~15.0.0-0"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",
-    "commander": "~14.0.0",
+    "commander": "~15.0.0-0",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^10.0.1",
     "globals": "^17.0.0",


### PR DESCRIPTION
Just changing the version number, and removing a stale comment in README.

Coming separately:
- switch to esm-only
- try and get combo typing right for negative option before positive potion, no longer setting default to `true` (could be hard and fallback is extra-typings has extra type for `true`!)