### PR TITLE
Tighten default value types for .option() and .requiredOption()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,23 @@ type InferVariadic<S extends string, ArgT> = S extends `${string}...`
   ? ArgT[]
   : ArgT;
 
+// Allowed default value type based on whether the option takes an argument.
+// Required variadic <value...>: string[] only.
+// Optional variadic [value...]: string[] or boolean (flag-only use returns true as preset).
+// Required non-variadic <value>: string only.
+// Optional non-variadic [value]: string or boolean (flag-only use returns true as preset).
+// Boolean flags (no argument): boolean only.
+type AllowedDefaultType<S extends string> =
+  S extends `${string} <${string}...>`
+    ? string[]
+    : S extends `${string} [${string}...]`
+      ? string[] | boolean
+      : S extends `${string} <${string}>`
+        ? string
+        : S extends `${string} [${string}]`
+          ? string | boolean
+          : boolean;
+
 type InferArgumentType<Value extends string, DefaultT, CoerceT, ChoicesT> = [
   CoerceT,
 ] extends [undefined]
@@ -1031,7 +1048,7 @@ export class Command<
     InferOptions<Opts, S, undefined, undefined, false>,
     GlobalOpts
   >;
-  option<S extends string, DefaultT extends string | boolean | string[] | []>(
+  option<S extends string, DefaultT extends AllowedDefaultType<S>>(
     usage: S,
     description?: string,
     defaultValue?: DefaultT,
@@ -1066,10 +1083,7 @@ export class Command<
     InferOptions<Opts, S, undefined, undefined, true>,
     GlobalOpts
   >;
-  requiredOption<
-    S extends string,
-    DefaultT extends string | boolean | string[],
-  >(
+  requiredOption<S extends string, DefaultT extends AllowedDefaultType<S>>(
     usage: S,
     description?: string,
     defaultValue?: DefaultT,

--- a/tests/options.test-d.ts
+++ b/tests/options.test-d.ts
@@ -38,62 +38,74 @@ expectType<{ debug: string }>(o7);
 const o8 = program.option('--debug [value]', 'description', 'default').opts();
 expectType<{ debug: string | true }>(o8);
 
-const o9 = program.option('--debug <value...>', 'description', []).opts();
-expectType<{ debug: [] | string[] }>(o9);
+const o9 = program.option('--debug [value]', 'description', false).opts();
+expectType<{ debug: string | boolean }>(o9);
 
-const o10 = program.option('--debug [value...]', 'description', []).opts();
-expectType<{ debug: string[] | true | [] }>(o10);
+const o10 = program.option('--debug <value...>', 'description', [] as string[]).opts();
+expectType<{ debug: string[] }>(o10);
+
+const o11 = program.option('--debug <value...>', 'description', ['a', 'b']).opts();
+expectType<{ debug: string[] }>(o11);
+
+const o12 = program.option('--debug [value...]', 'description', [] as string[]).opts();
+expectType<{ debug: string[] | true }>(o12);
+
+const o13 = program.option('--debug [value...]', 'description', ['a']).opts();
+expectType<{ debug: string[] | true }>(o13);
+
+const o14 = program.option('--debug [value...]', 'description', false).opts();
+expectType<{ debug: string[] | boolean }>(o14);
 
 // Coerce/custom, w/wo defaults
 
-const o11 = program.option('--debug <value>', 'description', myParseInt).opts();
-expectType<{ debug?: number }>(o11);
+const o15 = program.option('--debug <value>', 'description', myParseInt).opts();
+expectType<{ debug?: number }>(o15);
 
-const o12 = program
+const o16 = program
   .option('--debug <value>', 'description', myParseInt, 11)
   .opts();
-expectType<{ debug: number }>(o12);
+expectType<{ debug: number }>(o16);
 
-const o13 = program
+const o17 = program
   .option('--debug [value...]', 'description', myParseInts)
   .opts();
-expectType<{ debug?: true | number[] }>(o13);
+expectType<{ debug?: true | number[] }>(o17);
 
-const o14 = program
+const o18 = program
   .option('--debug [value...]', 'description', myParseInts, [])
   .opts();
-expectType<{ debug: true | number[] }>(o14);
+expectType<{ debug: true | number[] }>(o18);
 
 // requiredOption
 
-const o15 = program.requiredOption('--debug <value>', 'description').opts();
-expectType<{ debug: string }>(o15);
+const o19 = program.requiredOption('--debug <value>', 'description').opts();
+expectType<{ debug: string }>(o19);
 
-const o16 = program.requiredOption('--debug [value]', 'description').opts();
-expectType<{ debug: string | true }>(o16);
+const o20 = program.requiredOption('--debug [value]', 'description').opts();
+expectType<{ debug: string | true }>(o20);
 
 // negated
 
-const o17 = program.option('--C, --no-colour').opts();
-expectType<{ colour: boolean }>(o17);
+const o21 = program.option('--C, --no-colour').opts();
+expectType<{ colour: boolean }>(o21);
 
-const o18 = program
+const o22 = program
   .option('--c, --colour <string>')
   .option('--C, --no-colour')
   .opts();
-expectType<{ colour?: string | false }>(o18);
+expectType<{ colour?: string | false }>(o22);
 
-const o19 = program
+const o23 = program
   .option('--c, --colour <string>', 'description', 'red')
   .option('--C, --no-colour')
   .opts();
-expectType<{ colour: string | false }>(o19);
+expectType<{ colour: string | false }>(o23);
 
-const o20 = program
+const o24 = program
   .addOption(new Option('-c, --colour').default(0).preset(BigInt(3)))
   .addOption(new Option('-C, --no-colour').preset('on'))
   .opts();
-expectType<{ colour: 'on' | 0 | bigint }>(o20);
+expectType<{ colour: 'on' | 0 | bigint }>(o24);
 
 // multiple
 
@@ -112,8 +124,8 @@ expectType<{ debug?: true }>(ao1);
 const ao2 = program.addOption(new Option('-de, --debug <value>')).opts();
 expectType<{ debug?: string }>(ao2);
 
-const ao9 = program.addOption(new Option('-de, --debug [value]')).opts();
-expectType<{ debug?: string | true }>(ao9);
+const ao10 = program.addOption(new Option('-de, --debug [value]')).opts();
+expectType<{ debug?: string | true }>(ao10);
 
 const ao3 = program
   .addOption(new Option('-de, --debug <value>').default('foo'))
@@ -254,13 +266,37 @@ const co8 = program
 expectType<{ foo: 'C' | 'D' }>(co8);
 
 // default after choices creates union type
-const co9 = program
+const co10 = program
   .addOption(new Option('--foo <val>').choices(['C']).default('D'))
   .opts();
-expectType<{ foo: 'C' | 'D' }>(co9);
+expectType<{ foo: 'C' | 'D' }>(co10);
 
 // make mandatory before choices makes option mandatory
 const c10 = program
   .addOption(new Option('--foo <val>').makeOptionMandatory().choices(['C']))
   .opts();
 expectType<{ foo: 'C' }>(c10);
+
+// mismatched defaults should be errors
+
+// string default on a boolean flag is an error
+// @ts-expect-error
+program.option('--debug', 'description', 'string-value');
+
+// boolean default on a required option is an error
+// @ts-expect-error
+program.option('--debug <value>', 'description', false);
+// @ts-expect-error
+program.option('--debug <value...>', 'description', false);
+
+// string[] default on a non-variadic flag is an error
+// @ts-expect-error
+program.option('--debug <value>', 'description', ['arr']);
+// @ts-expect-error
+program.option('--debug [value]', 'description', ['arr']);
+
+// string default on a variadic flag is an error
+// @ts-expect-error
+program.option('--debug <value...>', 'description', 'str');
+// @ts-expect-error
+program.option('--debug [value...]', 'description', 'str');


### PR DESCRIPTION
<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed.
  npm run test

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.
-->

## Problem

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

Typings could be tighter for default value parameter for .option() 

GitHub fixes GH-158

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.
-->

Add `AllowedDefaultType<S>` to constrain the default value based on the option usage string:

* Boolean flags (`--flag`): boolean
* Required non-variadic (`--flag <value>`): string
* Required variadic (`--flag <value...>`): string[]
* Optional non-variadic (`--flag [value]`): string | boolean
* Optional variadic (`--flag [value...]`): string[] | boolean

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
