### PR TITLE
Update docs and prepare for 15.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The version numbering does not follow semantic versioning but instead aligns wit
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
+## [15.0.0] (2026-05-29)
+
+### Added
+
+- [Release Policy document](./docs/release-policy.md)
+  
+### Changed
+
+- *Breaking:* peer dependency on Commander 15.0.x which requires Node.js 22.12 or higher
+- update dependencies
+- old major versions now supported for 12 months instead of just previous major version, to give predictable end-of-life date
+
 ## [14.0.0] (2025-05-18)
 
 ### Added
@@ -207,6 +219,7 @@ Published from wrong branch.
 - inferred types for `.action()`
 - inferred types for `.opts()`
 
+[15.0.0]: https://github.com/commander-js/extra-typings/compare/v14.0.0...v15.0.0
 [14.0.0]: https://github.com/commander-js/extra-typings/compare/v13.1.0...v14.0.0
 [13.1.0]: https://github.com/commander-js/extra-typings/compare/v13.0.0...v13.1.0
 [13.0.0]: https://github.com/commander-js/extra-typings/compare/v12.1.0...v13.0.0

--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ const program = new Command()
   .option('-d, --debug');
 const options = program.opts(); // smart type
 ```
+
+## Support
+
+The current version of `@commander-js/extra-typings` is fully supported on Long Term Support versions of Node.js, and requires at least v22.12.0.
+
+Older major versions receive security updates for 12 months. For more see: [Release Policy](./docs/release-policy.md).
+
+The main forum for free and community support is the project [Issues](https://github.com/commander-js/extra-typings/issues) on GitHub.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,7 @@
 # Security Policy
 
-## Supported Versions
-
-Security updates are supported for the current version and the previous major version.
-
-## Reporting a Vulnerability
-
 To report a security vulnerability, please use the
 [Tidelift security contact](https://tidelift.com/security).
 Tidelift will coordinate the fix and disclosure.
+
+Please do not report security vulnerabilities through public GitHub issues or pull requests.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,14 @@
+# Release Policy
+
+The version numbering does not follow semantic versioning but instead aligns with the `commander` version number. The installed version of this package should match the major and minor version numbers of the installed commander package, but the patch version number is independent (following pattern used by [Definitely Typed](https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library)).
+
+The release notes for major versions highlight breaking changes, and include a section of migration tips for common changes required.
+The [changelog](../CHANGELOG.md) lists release notes for all versions.
+
+The current release line gets all updates: features, bug fixes, and security updates. Older maintenance versions get just security updates for 12 months.
+
+| Version | First Release | Release Note |  Status | End of Life |
+| ------- | ------------- | - | ------- | ----------- |
+| 15.x | 2026-05-29 | [15.0.0](https://github.com/commander-js/extra-typings/releases/tag/v15.0.0) | current | - |
+| 14.x | 2025-05-18 | [14.0.0](https://github.com/commander-js/extra-typings/releases/tag/v14.0.0) | maintenance | 2027-05-29 |
+| <14 | | | end of life | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "15.0.0-0",
+  "version": "15.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commander-js/extra-typings",
-      "version": "15.0.0-0",
+      "version": "15.0.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commander-js/extra-typings",
-  "version": "15.0.0-0",
+  "version": "15.0.0",
   "description": "Infer strong typings for commander options and action handlers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I added a release policy copied from Commander. I was rewording the bit about Semantic Versioning before discovering already had a good explanation in Changelog here, so just copied that directly.

I have updated package version number, but not 2 x dependencies on Commander yet, will update those when 15.0.0 is available since `package-lock.json` needs checksum.