### PR TITLE
Pin GitHub actions with hash

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 permissions:
   contents: read
@@ -16,9 +16,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         cache: 'npm'
         node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
## Problem

1) Best practice to lower risk of supply chain attacks is to pin GitHub Actions to hash.

2) Can't manually run actions on branches (e.g. run CodeQL on `release/15.x`)

## Solution

1) Switch to hashes using `npx actions-up`. In theory, dependabot will update the cases and maintain the version number comment from now on, so this is a one-shot.

https://github.com/azat-io/actions-up

2) Add `workflow_dispatch` to events for actions.

https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#configuring-a-workflow-to-run-manually

