### PR TITLE
Tune updates for @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       # group simple version updates, leave major updates and security updates as single pull requests
       minor-and-patch:


### PR DESCRIPTION
Best practice to catch accidental use of new features is use @types/node for oldest support major. Add a rule so do not get unwanted Pull Requests from dependabot.